### PR TITLE
Removing the findbugs-jsr305 dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,6 @@ libraryDependencies ++= List(
   "org.sonarsource.sonarqube" % "sonar-plugin-api" % sonarVersion % Provided,
   "org.slf4j" % "slf4j-api" % "1.7.25" % Provided,
   "org.scalariform" %% "scalariform" % "0.2.6",
-  "com.google.code.findbugs" % "jsr305" % "3.0.2",
   "org.scalastyle" %% "scalastyle" % "1.0.0",
   "com.google.guava" % "guava" % "23.0",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,


### PR DESCRIPTION
This fixes #45.

Additionally, I've been playing with the dependencies, and I noticed that when we refactor the scalastyle plugin we could and should remove the sonar-core and the google-guava dependencies as well.