### PR TITLE
Changing the scoverage report path property key

### DIFF
--- a/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
+++ b/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
@@ -44,14 +44,17 @@ object Scala {
   private val FileSuffixesPropertyKey = "sonar.scala.file.suffixes"
   private val DefaultFileSuffixes = Array(".scala")
   private val ScalaVersionPropertyKey = "sonar.scala.version"
+  private val DefaultScalaVersion = ScalaVersions.Scala_2_11.toString()
   private val SourcesPropertyKey = "sonar.sources"
+  private val DefaultSourcesFolder = "src/main/scala"
 
   def getScalaVersion(settings: Configuration): String =
-    settings.get(ScalaVersionPropertyKey).toOption.getOrElse(ScalaVersions.Scala_2_11.toString())
+    settings.get(ScalaVersionPropertyKey).toOption.getOrElse(DefaultScalaVersion)
 
-  // because the 'sonar.sources' property is guaranteed to always be present, it is safe to call get
+  // even if the 'sonar.sources' property is mandatory,
+  // we add a default value to ensure a safe access to it
   def getSourcesPath(settings: Configuration): String =
-    settings.get(SourcesPropertyKey).get
+    settings.get(SourcesPropertyKey).toOption.filter(_.nonEmpty).getOrElse(DefaultSourcesFolder)
 
   def tokenize(sourceCode: String, scalaVersion: String): List[Token] =
     ScalaLexer.createRawLexer(sourceCode, forgiveErrors = false, scalaVersion).toList

--- a/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
+++ b/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
@@ -45,13 +45,13 @@ object Scala {
   private val DefaultFileSuffixes = Array(".scala")
   private val ScalaVersionPropertyKey = "sonar.scala.version"
   private val SourcesPropertyKey = "sonar.sources"
-  private val DefaultSources = "src/main/scala"
 
   def getScalaVersion(settings: Configuration): String =
     settings.get(ScalaVersionPropertyKey).toOption.getOrElse(ScalaVersions.Scala_2_11.toString())
 
+  // because the 'sonar.sources' property is guaranteed to always be present, it is safe to call get
   def getSourcesPath(settings: Configuration): String =
-    settings.get(SourcesPropertyKey).toOption.getOrElse(DefaultSources)
+    settings.get(SourcesPropertyKey).get
 
   def tokenize(sourceCode: String, scalaVersion: String): List[Token] =
     ScalaLexer.createRawLexer(sourceCode, forgiveErrors = false, scalaVersion).toList

--- a/src/main/scala/com/mwz/sonar/scala/scoverage/ScoverageSensor.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scoverage/ScoverageSensor.scala
@@ -115,14 +115,30 @@ private[scoverage] abstract class ScoverageSensorInternal extends Sensor {
   }
 
   /** Returns the filename of the scoverage report for this module */
-  private[this] def getScoverageReportFilename(settings: Configuration): String = {
-    settings
-      .get(ScoverageSensorInternal.ScoverageReportPathPropertyKey)
-      .toOption
-      .getOrElse(
-        ScoverageSensorInternal.getDefaultScoverageReportPath(Scala.getScalaVersion(settings))
-      )
-  }
+  private[this] def getScoverageReportFilename(settings: Configuration): String =
+    settings.get(ScoverageSensorInternal.OldScoverageReportPathPropertyKey).toOption match {
+      case Some(path) => {
+        logger.warn(
+          s"""[scoverage] The property: '${ScoverageSensorInternal.OldScoverageReportPathPropertyKey}' is deprecated,
+             |use the new property '${ScoverageSensorInternal.NewScoverageReportPathPropertyKey}' instead""".stripMargin
+        )
+        path
+      }
+      case None => {
+        settings
+          .get(ScoverageSensorInternal.NewScoverageReportPathPropertyKey)
+          .toOption
+          .getOrElse {
+            val scalaVersion = Scala.getScalaVersion(settings)
+            val default = ScoverageSensorInternal.getDefaultScoverageReportPath(scalaVersion)
+            logger.info(
+              s"""[scoverage] Missing the property: '${ScoverageSensorInternal.NewScoverageReportPathPropertyKey}',
+                 |using the default value: '${default}'""".stripMargin
+            )
+            default
+          }
+      }
+    }
 
   /** Saves the [[ScoverageMetrics]] of a component */
   private[this] def saveComponentScoverage(
@@ -162,7 +178,8 @@ private[scoverage] abstract class ScoverageSensorInternal extends Sensor {
 
 object ScoverageSensorInternal {
   private val SensorName = "Scoverage Sensor"
-  private val ScoverageReportPathPropertyKey = "sonar.scoverage.reportPath"
+  private val OldScoverageReportPathPropertyKey = "sonar.scoverage.reportPath"
+  private val NewScoverageReportPathPropertyKey = "sonar.scala.scoverage.reportPath"
   private def getDefaultScoverageReportPath(scalaRawVersion: String) = {
     // remove the extra part of the scala version, e.g 2.11.0 -> 2.11
     val scalaVersion = scalaRawVersion.take(scalaRawVersion.lastIndexOf("."))

--- a/src/main/scala/com/mwz/sonar/scala/scoverage/ScoverageSensor.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scoverage/ScoverageSensor.scala
@@ -115,30 +115,36 @@ private[scoverage] abstract class ScoverageSensorInternal extends Sensor {
   }
 
   /** Returns the filename of the scoverage report for this module */
-  private[this] def getScoverageReportFilename(settings: Configuration): String =
-    settings.get(ScoverageSensorInternal.OldScoverageReportPathPropertyKey).toOption match {
-      case Some(path) => {
-        logger.warn(
-          s"""[scoverage] The property: '${ScoverageSensorInternal.OldScoverageReportPathPropertyKey}' is deprecated,
-             |use the new property '${ScoverageSensorInternal.NewScoverageReportPathPropertyKey}' instead""".stripMargin
-        )
-        path
-      }
-      case None => {
-        settings
-          .get(ScoverageSensorInternal.NewScoverageReportPathPropertyKey)
-          .toOption
-          .getOrElse {
-            val scalaVersion = Scala.getScalaVersion(settings)
-            val default = ScoverageSensorInternal.getDefaultScoverageReportPath(scalaVersion)
-            logger.info(
-              s"""[scoverage] Missing the property: '${ScoverageSensorInternal.NewScoverageReportPathPropertyKey}',
-                 |using the default value: '${default}'""".stripMargin
-            )
-            default
-          }
-      }
+  private[this] def getScoverageReportFilename(settings: Configuration): String = {
+    import ScoverageSensorInternal.DeprecatedScoverageReportPathPropertyKey
+    import ScoverageSensorInternal.ScoverageReportPathPropertyKey
+
+    val scalaVersion = Scala.getScalaVersion(settings)
+    val defaultScoverageReportPath = ScoverageSensorInternal.getDefaultScoverageReportPath(scalaVersion)
+
+    // logging logic
+    if (settings.hasKey(ScoverageReportPathPropertyKey)) {
+      logger.warn(
+        s"""[scoverage] The property: '${DeprecatedScoverageReportPathPropertyKey}' is deprecated,
+           |use the new property '${ScoverageReportPathPropertyKey}' instead""".stripMargin
+      )
+    } else if (!settings.hasKey(ScoverageReportPathPropertyKey)) {
+      logger.info(
+        s"""[scoverage] Missing the property: '${ScoverageReportPathPropertyKey}',
+           |using the default value: '${defaultScoverageReportPath}'""".stripMargin
+      )
     }
+
+    settings
+      .get(DeprecatedScoverageReportPathPropertyKey)
+      .toOption
+      .getOrElse(
+        settings
+          .get(ScoverageReportPathPropertyKey)
+          .toOption
+          .getOrElse(defaultScoverageReportPath)
+      )
+  }
 
   /** Saves the [[ScoverageMetrics]] of a component */
   private[this] def saveComponentScoverage(
@@ -178,8 +184,8 @@ private[scoverage] abstract class ScoverageSensorInternal extends Sensor {
 
 object ScoverageSensorInternal {
   private val SensorName = "Scoverage Sensor"
-  private val OldScoverageReportPathPropertyKey = "sonar.scoverage.reportPath"
-  private val NewScoverageReportPathPropertyKey = "sonar.scala.scoverage.reportPath"
+  private val DeprecatedScoverageReportPathPropertyKey = "sonar.scoverage.reportPath"
+  private val ScoverageReportPathPropertyKey = "sonar.scala.scoverage.reportPath"
   private def getDefaultScoverageReportPath(scalaRawVersion: String) = {
     // remove the extra part of the scala version, e.g 2.11.0 -> 2.11
     val scalaVersion = scalaRawVersion.take(scalaRawVersion.lastIndexOf("."))

--- a/src/test/scala/com/mwz/sonar/scala/scoverage/ScoverageSensorSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scoverage/ScoverageSensorSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{FlatSpec, LoneElement, Matchers}
 import org.sonar.api.batch.fs.InputFile
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder
 import org.sonar.api.batch.sensor.internal.{DefaultSensorDescriptor, SensorContextTester}
+import org.sonar.api.config.internal.MapSettings
 
 /** Tests the Scoverage Sensor */
 class ScoverageSensorSpec extends FlatSpec with SensorContextMatchers with LoneElement with Matchers {
@@ -42,6 +43,7 @@ class ScoverageSensorSpec extends FlatSpec with SensorContextMatchers with LoneE
   it should "save the coverage metrics of a one file module" in {
     //prepare the sensor context
     val context = SensorContextTester.create(Paths.get("./"))
+    context.setSettings(new MapSettings().setProperty("sonar.sources", "src/main/scala"))
     val mainFile = TestInputFileBuilder
       .create("./", "src/main/scala/package/Main.scala")
       .setLanguage("scala")


### PR DESCRIPTION
Fixes #36.

Additionally this removes the _misleading_ default value of the `'sonar.sources'` **property**.