### PR TITLE
Fixing some ScalaStyle issues

### DIFF
--- a/src/main/scala/com/mwz/sonar/scala/sensor/Measures.scala
+++ b/src/main/scala/com/mwz/sonar/scala/sensor/Measures.scala
@@ -21,10 +21,15 @@ package com.mwz.sonar.scala.sensor
 import scala.annotation.tailrec
 import scalariform.lexer.{Token, Tokens}
 
+import scala.util.matching.Regex
+
 /** Scala Sensor Metrics */
 object Measures {
+
+  val NewLineRegex: Regex = "(\r\n)|\r|\n".r
+
   def countClasses(tokens: List[Token]): Int = {
-    tokens.foldLeft(0) {
+    tokens.foldLeft(0) { // scalastyle:ignore LiteralArguments
       case (acc, token) =>
         val tokenType = token.tokenType
         if (tokenType == Tokens.CLASS || tokenType == Tokens.OBJECT) acc + 1
@@ -33,7 +38,7 @@ object Measures {
   }
 
   def countMethods(tokens: List[Token]): Int = {
-    tokens.foldLeft(0) {
+    tokens.foldLeft(0) { // scalastyle:ignore LiteralArguments
       case (acc, token) =>
         if (token.tokenType == Tokens.DEF) acc + 1
         else acc
@@ -65,7 +70,9 @@ object Measures {
       tokens match {
         case Nil =>
           Nil
-        case token :: tail if token.tokenType == Tokens.WS && token.text.contains('\n') =>
+        case token :: tail
+            if token.tokenType == Tokens.WS &&
+            NewLineRegex.findFirstIn(token.text).nonEmpty =>
           tail
         case token :: tail if token.tokenType == Tokens.LINE_COMMENT =>
           tail

--- a/src/main/scala/com/mwz/sonar/scala/sensor/Measures.scala
+++ b/src/main/scala/com/mwz/sonar/scala/sensor/Measures.scala
@@ -18,9 +18,9 @@
  */
 package com.mwz.sonar.scala.sensor
 
-import scala.annotation.tailrec
 import scalariform.lexer.{Token, Tokens}
 
+import scala.annotation.tailrec
 import scala.util.matching.Regex
 
 /** Scala Sensor Metrics */

--- a/src/main/scala/com/mwz/sonar/scala/sensor/ScalaSensor.scala
+++ b/src/main/scala/com/mwz/sonar/scala/sensor/ScalaSensor.scala
@@ -33,7 +33,12 @@ final class ScalaSensor extends Sensor {
       context.fileSystem().inputFiles(context.fileSystem().predicates().hasLanguage(Scala.Key))
 
     inputFiles.asScala.foreach { inputFile =>
-      context.newMeasure().on(inputFile).forMetric(CM.FILES).withValue(1).save()
+      context
+        .newMeasure()
+        .on(inputFile)
+        .forMetric(CM.FILES)
+        .withValue(1) // scalastyle:ignore LiteralArguments
+        .save()
 
       val sourceCode = Source.fromFile(inputFile.uri, charset).mkString
       val tokens = Scala.tokenize(sourceCode, Scala.getScalaVersion(context.config()))

--- a/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleQualityProfile.scala
+++ b/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleQualityProfile.scala
@@ -65,7 +65,7 @@ class ScalastyleQualityProfile(ruleFinder: RuleFinder) extends ProfileDefinition
     profile
   }
 
-  def setParameters(activeRule: ActiveRule, clazz: String) {
+  def setParameters(activeRule: ActiveRule, clazz: String): Unit = {
     // set parameters
     defaultConfigRules.find(x => (x \ "@class").text.equals(clazz)) match {
       case Some(rule) =>

--- a/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleRepository.scala
+++ b/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleRepository.scala
@@ -90,7 +90,7 @@ class ScalastyleRepository extends RulesDefinition {
     @tailrec
     def getFreeRuleKey(key: String, count: Int, repo: NewRepository): String = {
       val ruleKey = if (count == 0) key else s"${key}_${count}"
-      //if the repo.rule method returns null, then the option will be empty
+      // if the repo.rule method returns null, then the option will be empty
       val repoRule = Option(repo.rule(ruleKey))
       if (repoRule.isEmpty) {
         ruleKey
@@ -99,6 +99,6 @@ class ScalastyleRepository extends RulesDefinition {
       }
     }
 
-    getFreeRuleKey(getStandardKey(clazz), 0, repo)
+    getFreeRuleKey(getStandardKey(clazz), count = 0, repo)
   }
 }

--- a/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleResources.scala
+++ b/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleResources.scala
@@ -32,15 +32,15 @@ import scala.xml.{Elem, Node, XML}
 object ScalastyleResources {
 
   // accessing scalastyles definition and documentation.xml files
-  private val definitions = xmlFromClassPath("/scalastyle_definition.xml")
-  private val documentation = xmlFromClassPath("/scalastyle_documentation.xml")
+  private val Definitions = xmlFromClassPath("/scalastyle_definition.xml")
+  private val Documentation = xmlFromClassPath("/scalastyle_documentation.xml")
 
   // accessing scalastyles reference.conf (includes additional data such as key.label)
-  private val cfg = ConfigFactory.load(this.getClass.getClassLoader)
+  private val Cfg = ConfigFactory.load(this.getClass.getClassLoader)
 
   def allDefinedRules: Seq[RepositoryRule] =
     for {
-      checker <- definitions \\ "checker"
+      checker <- Definitions \\ "checker"
       clazz = (checker \ "@class").text
       id = (checker \ "@id").text
       desc = description(id)
@@ -57,12 +57,12 @@ object ScalastyleResources {
     } yield Param(ruleParamKey, ruleParamType, description, defaultValue)
 
   def description(key: String): String =
-    descriptionFromDocumentation(key) getOrElse cfg.getConfig(key).getString("description")
+    descriptionFromDocumentation(key) getOrElse Cfg.getConfig(key).getString("description")
 
-  def label(key: String): String = cfg.getConfig(key).getString("label")
+  def label(key: String): String = Cfg.getConfig(key).getString("label")
 
   private def descriptionFromDocumentation(key: String): Option[String] = {
-    documentation \\ "scalastyle-documentation" \ "check" find { _ \\ "@id" exists (_.text == key) } match {
+    Documentation \\ "scalastyle-documentation" \ "check" find { _ \\ "@id" exists (_.text == key) } match {
       case Some(node) =>
         val justification = {
           val text = (node \ "justification").text
@@ -120,11 +120,11 @@ object ScalastyleDocFormatter {
     val count = line.takeWhile(_ == ' ').length
     LineWithLeadingSpaces(count, empty(line), line)
   }
-  private val margin = 2
+  private val Margin = 2
 
   def format(in: String): String = {
     val linesWithLeadingSpaces = Source.fromString(in).getLines().map(countLeadingSpaces).toList
-    val docLines = linesWithLeadingSpaces.map(l => DocLine(l.spaceCount > margin, l.empty, l.line))
+    val docLines = linesWithLeadingSpaces.map(l => DocLine(l.spaceCount > Margin, l.empty, l.line))
 
     docLines.foldLeft(Out(pre = false, appended = false, "")) {
       case (out @ Out(false, false, text), line) =>

--- a/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleRunner.scala
+++ b/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleRunner.scala
@@ -57,7 +57,7 @@ class ScalastyleRunner(rp: RulesProfile) {
   def config: ScalastyleConfiguration = {
     val sonarRules = rp.getActiveRulesByRepository(Constants.RepositoryKey)
     val checkers = sonarRules.asScala.map(ruleToChecker).toList
-    new ScalastyleConfiguration("sonar", true, checkers)
+    new ScalastyleConfiguration("sonar", commentFilter = true, checkers)
   }
 
   private def ruleToChecker(activeRule: ActiveRule): ConfigurationChecker = {

--- a/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleSensor.scala
+++ b/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleSensor.scala
@@ -113,5 +113,6 @@ class ScalastyleSensor(
   // sonar claims to accept null or a non zero lines, however if it is passed
   // null it blows up at runtime complaining it was passed 0
   /** Ensures that a line number is valid, if not returns 1 */
-  private def sanitiseLineNum(maybeLine: Option[Int]) = maybeLine.filter(_ > 0).getOrElse(1)
+  private def sanitiseLineNum(maybeLine: Option[Int]) =
+    maybeLine.filter(_ > 0).getOrElse(1) // scalastyle:ignore LiteralArguments
 }


### PR DESCRIPTION
I know that ScalaStyle sensor will be refactored soon, but in the meantime I fixed the following style issues (linked to #25):
- [LiteralArguments](https://sonar.sonar-scala.com/project/issues?resolved=false&rules=Scalastyle%3ALiteralArguments&id=sonar-scala)
- [ProcedureDeclarationChecker](https://sonar.sonar-scala.com/project/issues?id=sonar-scala&resolved=false&rules=Scalastyle%3Ascalastyle_ProcedureDeclarationChecker)
- [FieldName](https://sonar.sonar-scala.com/project/issues?id=sonar-scala&resolved=false&rules=Scalastyle%3AFieldName)
- [SpaceAfterCommentStartChecker](https://sonar.sonar-scala.com/project/issues?id=sonar-scala&resolved=false&rules=Scalastyle%3Ascalastyle_SpaceAfterCommentStartChecker)