### PR TITLE
Scapegoat sensor feature flag

### DIFF
--- a/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
+++ b/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
@@ -33,7 +33,6 @@ import com.mwz.sonar.scala.sensor.ScalaSensor
 import com.mwz.sonar.scala.util.JavaOptionals._
 import com.ncredinburgh.sonar.scalastyle.{ScalastyleQualityProfile, ScalastyleRepository, ScalastyleSensor}
 import org.sonar.api.Plugin
-import org.sonar.api.Plugin.Context
 import org.sonar.api.config.Configuration
 import org.sonar.api.resources.AbstractLanguage
 import org.sonar.api.utils.log.Loggers
@@ -113,7 +112,7 @@ object Scala {
 
 /** Sonar Scala plugin entry point */
 final class ScalaPlugin extends Plugin {
-  override def define(context: Context): Unit = {
+  override def define(context: Plugin.Context): Unit = {
     context.addExtensions(
       // Scala
       classOf[Scala],

--- a/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
+++ b/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
@@ -22,11 +22,18 @@ import java.nio.file.{Path, Paths}
 
 import cats.kernel.Eq
 import cats.syntax.eq._
+import com.mwz.sonar.scala.scapegoat.{
+  ScapegoatQualityProfile,
+  ScapegoatReportParser,
+  ScapegoatRulesRepository,
+  ScapegoatSensor
+}
 import com.mwz.sonar.scala.scoverage.{ScoverageMetrics, ScoverageReportParser, ScoverageSensor}
 import com.mwz.sonar.scala.sensor.ScalaSensor
 import com.mwz.sonar.scala.util.JavaOptionals._
 import com.ncredinburgh.sonar.scalastyle.{ScalastyleQualityProfile, ScalastyleRepository, ScalastyleSensor}
 import org.sonar.api.Plugin
+import org.sonar.api.Plugin.Context
 import org.sonar.api.config.Configuration
 import org.sonar.api.resources.AbstractLanguage
 import org.sonar.api.utils.log.Loggers
@@ -104,9 +111,9 @@ object Scala {
       .toList
 }
 
-/** Plugin entry point */
+/** Sonar Scala plugin entry point */
 final class ScalaPlugin extends Plugin {
-  override def define(context: Plugin.Context): Unit = {
+  override def define(context: Context): Unit = {
     context.addExtensions(
       // Scala
       classOf[Scala],
@@ -118,7 +125,12 @@ final class ScalaPlugin extends Plugin {
       // Scoverage
       classOf[ScoverageMetrics],
       classOf[ScoverageReportParser],
-      classOf[ScoverageSensor]
+      classOf[ScoverageSensor],
+      // Scapegoat
+      classOf[ScapegoatRulesRepository],
+      classOf[ScapegoatQualityProfile],
+      classOf[ScapegoatReportParser],
+      classOf[ScapegoatSensor]
     )
   }
 }

--- a/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatIssue.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatIssue.scala
@@ -16,7 +16,8 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package com.mwz.sonar.scala.scapegoat
+package com.mwz.sonar.scala
+package scapegoat
 
 /** Represents a warning/issue in the scapegoat report */
 private[scapegoat] final case class ScapegoatIssue(

--- a/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepository.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepository.scala
@@ -54,6 +54,6 @@ final class ScapegoatRulesRepository extends RulesDefinition {
 }
 
 private[scapegoat] object ScapegoatRulesRepository {
-  final val RepositoryKey = "sonar-scala-scapegoat-repository"
+  final val RepositoryKey = "sonar-scala-scapegoat"
   final val RepositoryName = "Scapegoat"
 }

--- a/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepository.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepository.scala
@@ -19,11 +19,10 @@
 package com.mwz.sonar.scala
 package scapegoat
 
-import inspections.Level
-import inspections.ScapegoatInspection.AllScapegoatInspections
-import org.sonar.api.server.rule.RulesDefinition
+import com.mwz.sonar.scala.scapegoat.inspections.ScapegoatInspection.AllScapegoatInspections
 import org.sonar.api.rule.RuleStatus
 import org.sonar.api.rules.RuleType
+import org.sonar.api.server.rule.RulesDefinition
 
 /** Defines a rules repository for the Scapegoat inspections */
 final class ScapegoatRulesRepository extends RulesDefinition {

--- a/src/test/scala/com/mwz/sonar/scala/ScalaPluginSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/ScalaPluginSpec.scala
@@ -18,6 +18,12 @@
  */
 package com.mwz.sonar.scala
 
+import com.mwz.sonar.scala.scapegoat.{
+  ScapegoatQualityProfile,
+  ScapegoatReportParser,
+  ScapegoatRulesRepository,
+  ScapegoatSensor
+}
 import com.mwz.sonar.scala.scoverage.{ScoverageMetrics, ScoverageReportParser, ScoverageSensor}
 import com.mwz.sonar.scala.sensor.ScalaSensor
 import com.ncredinburgh.sonar.scalastyle.{ScalastyleQualityProfile, ScalastyleRepository, ScalastyleSensor}
@@ -48,5 +54,12 @@ class ScalaPluginSpec extends FlatSpec with Matchers {
     assert(context.getExtensions.contains(classOf[ScoverageMetrics]))
     assert(context.getExtensions.contains(classOf[ScoverageReportParser]))
     assert(context.getExtensions.contains(classOf[ScoverageSensor]))
+  }
+
+  it should "provide scapegoat sensor" in {
+    assert(context.getExtensions.contains(classOf[ScapegoatRulesRepository]))
+    assert(context.getExtensions.contains(classOf[ScapegoatQualityProfile]))
+    assert(context.getExtensions.contains(classOf[ScapegoatReportParser]))
+    assert(context.getExtensions.contains(classOf[ScapegoatSensor]))
   }
 }

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatQualityProfileSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatQualityProfileSpec.scala
@@ -62,7 +62,7 @@ class ScapegoatQualityProfileSpec extends FlatSpec with Inspectors with LoneElem
 
   it should "be from the Scapegaot Rules Repository" in {
     forEvery(rules) { rule =>
-      rule.repoKey shouldBe "sonar-scala-scapegoat-repository"
+      rule.repoKey shouldBe "sonar-scala-scapegoat"
     }
   }
 }

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepositorySpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepositorySpec.scala
@@ -40,7 +40,7 @@ class ScapegoatRulesRepositorySpec extends FlatSpec with Inspectors with LoneEle
   it should "properly define the properties of the repository" in {
     val scapegoatRepository = context.repositories.loneElement
 
-    scapegoatRepository.key shouldBe "sonar-scala-scapegoat-repository"
+    scapegoatRepository.key shouldBe "sonar-scala-scapegoat"
     scapegoatRepository.name shouldBe "Scapegoat"
     scapegoatRepository.language shouldBe "scala"
   }
@@ -66,7 +66,7 @@ class ScapegoatRulesRepositorySpec extends FlatSpec with Inspectors with LoneEle
   }
 
   // tests about properties of the scapegoat repository rules
-  val scapegoatRepository = context.repository("sonar-scala-scapegoat-repository")
+  val scapegoatRepository = context.repository("sonar-scala-scapegoat")
   val rules = scapegoatRepository.rules
   behavior of "all Scapegoat Rules"
 

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatSensorSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatSensorSpec.scala
@@ -105,7 +105,7 @@ class ScapegoatSensorSpec
     descriptor.name shouldBe "Scapegoat Sensor"
     descriptor.`type` shouldBe InputFile.Type.MAIN
     descriptor.languages.loneElement shouldBe "scala"
-    descriptor.ruleRepositories.loneElement shouldBe "sonar-scala-scapegoat-repository"
+    descriptor.ruleRepositories.loneElement shouldBe "sonar-scala-scapegoat"
   }
 
   it should "get default scapegoat report path, when the scala version property is missing" in {
@@ -184,28 +184,28 @@ class ScapegoatSensorSpec
     val activeRulesBuilder = new ActiveRulesBuilder()
 
     val emptyClassRuleKey =
-      RuleKey.of("sonar-scala-scapegoat-repository", "Empty case class")
+      RuleKey.of("sonar-scala-scapegoat", "Empty case class")
     activeRulesBuilder
       .create(emptyClassRuleKey)
       .setInternalKey("com.sksamuel.scapegoat.inspections.EmptyCaseClass")
       .activate()
 
     val arrayPassedToStringFormatRuleKey =
-      RuleKey.of("sonar-scala-scapegoat-repository", "Array passed to String.forma")
+      RuleKey.of("sonar-scala-scapegoat", "Array passed to String.forma")
     activeRulesBuilder
       .create(arrayPassedToStringFormatRuleKey)
       .setInternalKey("com.sksamuel.scapegoat.inspections.string.ArraysInFormat")
       .activate()
 
     val lonelySealedTraitRuleKey =
-      RuleKey.of("sonar-scala-scapegoat-repository", "Lonely sealed trait")
+      RuleKey.of("sonar-scala-scapegoat", "Lonely sealed trait")
     activeRulesBuilder
       .create(lonelySealedTraitRuleKey)
       .setInternalKey("com.sksamuel.scapegoat.inspections.LonelySealedTrait")
       .activate()
 
     val redundantFinalModifierOnMethodRuleKey =
-      RuleKey.of("sonar-scala-scapegoat-repository", "Redundant final modifier on method")
+      RuleKey.of("sonar-scala-scapegoat", "Redundant final modifier on method")
     activeRulesBuilder
       .create(redundantFinalModifierOnMethodRuleKey)
       .setInternalKey("com.sksamuel.scapegoat.inspections.RedundantFinalModifierOnMethod")
@@ -311,7 +311,7 @@ class ScapegoatSensorSpec
     val activeRulesBuilder = new ActiveRulesBuilder()
 
     val emptyClassRuleKey =
-      RuleKey.of("sonar-scala-scapegoat-repository", "Empty case class")
+      RuleKey.of("sonar-scala-scapegoat", "Empty case class")
     activeRulesBuilder
       .create(emptyClassRuleKey)
       .setInternalKey("com.sksamuel.scapegoat.inspections.EmptyCaseClass")


### PR DESCRIPTION
Introduces a new property `sonar.scala.scapegoat.disable` which allows to disable execution of this sensor if set to `true` (it's `false` by default).

```
[info] INFO: [scapegoat] The Scapegoat sensor was disabled in the configuration - skipping scapegoat analysis.
[info] INFO: Sensor Scapegoat Sensor [scala] (done) | time=3ms
```

It might be useful for those who use another standalone Scapegoat plugin or simply don't want to include Scapegoat report in their analysis.

I hope that you don't mind @BalmungSan, but I also shortened the key of the Scapegoat repository to `sonar-scala-scapegoat`, which makes it a little bit more concise in the UI.

Related to #8.