### PR TITLE
Fix for Scapegoat sensor not respecting module path for multi module projects.

### DIFF
--- a/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
+++ b/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
@@ -86,7 +86,7 @@ object Scala {
     if (scalaVersion === DefaultScalaVersion)
       logger.warn(
         s"[sonar-scala] The '$ScalaVersionPropertyKey' is not properly set or is missing, " +
-        s"using the default value: '$DefaultScalaVersion'"
+        s"using the default value: '$DefaultScalaVersion'."
       )
 
     scalaVersion

--- a/src/main/scala/com/mwz/sonar/scala/scoverage/ScoverageSensor.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scoverage/ScoverageSensor.scala
@@ -19,14 +19,16 @@
 package com.mwz.sonar.scala
 package scoverage
 
+import java.nio.file.{Path, Paths}
+
 import com.mwz.sonar.scala.util.JavaOptionals._
+import com.mwz.sonar.scala.util.PathUtils._
 import com.mwz.sonar.scala.util.{Log, PathUtils}
 import org.sonar.api.batch.fs.{FileSystem, InputComponent, InputFile}
 import org.sonar.api.batch.sensor.{Sensor, SensorContext, SensorDescriptor}
 import org.sonar.api.config.Configuration
 import scalariform.ScalaVersion
 
-import java.nio.file.{Path, Paths}
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
@@ -47,7 +49,7 @@ final class ScoverageSensor(scoverageReportParser: ScoverageReportParserAPI) ext
   /** Saves in SonarQube the scoverage information of a module */
   override def execute(context: SensorContext): Unit = {
     log.info("Initializing the scoverage sensor.")
-    log.debug(s"The current working directory (CWD) is: '${PathUtils.cwd}'.")
+    log.debug(s"The current working directory is: '${PathUtils.cwd}'.")
     val settings = context.config
     val filesystem = context.fileSystem
 
@@ -108,13 +110,6 @@ final class ScoverageSensor(scoverageReportParser: ScoverageReportParserAPI) ext
       )
 
     fs.inputFiles(predicate).asScala
-  }
-
-  /** Returns the module base path */
-  private[scoverage] def getModuleBaseDirectory(fs: FileSystem): Path = {
-    val moduleAbsolutePath = Paths.get(fs.baseDir().getAbsolutePath).normalize
-    val currentWorkdirAbsolutePath = PathUtils.cwd
-    currentWorkdirAbsolutePath.relativize(moduleAbsolutePath)
   }
 
   /** Returns the filename of the scoverage report for this module */

--- a/src/main/scala/com/mwz/sonar/scala/util/util.scala
+++ b/src/main/scala/com/mwz/sonar/scala/util/util.scala
@@ -22,6 +22,8 @@ package util
 import java.nio.file.{Path, Paths}
 import java.util.Optional
 
+import org.sonar.api.batch.fs.FileSystem
+
 import scala.language.implicitConversions
 
 /**
@@ -65,4 +67,13 @@ object PathUtils {
   def stripOutPrefix(prefix: Path, path: Path): Path =
     if (path.startsWith(prefix)) prefix.relativize(path)
     else path
+
+  /**
+   * Returns the module base path relative to the current working directory
+   * */
+  def getModuleBaseDirectory(fs: FileSystem): Path = {
+    val moduleAbsolutePath = Paths.get(fs.baseDir().getAbsolutePath).normalize
+    val currentWorkdirAbsolutePath = PathUtils.cwd
+    currentWorkdirAbsolutePath.relativize(moduleAbsolutePath)
+  }
 }

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatSensorSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatSensorSpec.scala
@@ -380,7 +380,7 @@ class ScapegoatSensorSpec
     sensorContext.allIssues shouldBe empty
   }
 
-  it should "not report module issues" in {
+  it should "report module issues" in {
     // create the sensor context
     val sensorContext = SensorContextTester.create(Paths.get("./"))
     val filesystem = new DefaultFileSystem(Paths.get("./module1"))

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatSensorSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatSensorSpec.scala
@@ -134,11 +134,27 @@ class ScapegoatSensorSpec
     reportPath shouldBe Paths.get("target", "report-path")
   }
 
-  it should "get a module file using the filename extracted from the scapegoat report" in {
+  it should "get a root module file using the filename extracted from the scapegoat report" in {
     val filesystem = new DefaultFileSystem(Paths.get("./"))
 
     val testFileA = TestInputFileBuilder
       .create("", "src/main/scala/com/mwz/sonar/scala/scapegoat/TestFileA.scala")
+      .setLanguage("scala")
+      .setType(InputFile.Type.MAIN)
+      .build()
+    filesystem.add(testFileA)
+
+    val moduleFile =
+      scapegoatSensor.getModuleFile("com/mwz/sonar/scala/scapegoat/TestFileA.scala", filesystem)
+
+    moduleFile.value shouldBe testFileA
+  }
+
+  it should "get a module file using the filename extracted from the scapegoat report" in {
+    val filesystem = new DefaultFileSystem(Paths.get("./module1"))
+
+    val testFileA = TestInputFileBuilder
+      .create("module1", "src/main/scala/com/mwz/sonar/scala/scapegoat/TestFileA.scala")
       .setLanguage("scala")
       .setType(InputFile.Type.MAIN)
       .build()
@@ -195,7 +211,7 @@ class ScapegoatSensorSpec
       .activate()
 
     val arrayPassedToStringFormatRuleKey =
-      RuleKey.of("sonar-scala-scapegoat", "Array passed to String.forma")
+      RuleKey.of("sonar-scala-scapegoat", "Array passed to String.format")
     activeRulesBuilder
       .create(arrayPassedToStringFormatRuleKey)
       .setInternalKey("com.sksamuel.scapegoat.inspections.string.ArraysInFormat")
@@ -363,6 +379,62 @@ class ScapegoatSensorSpec
     // validate the sensor behavior
     sensorContext.allIssues shouldBe empty
   }
+
+  it should "not report module issues" in {
+    // create the sensor context
+    val sensorContext = SensorContextTester.create(Paths.get("./"))
+    val filesystem = new DefaultFileSystem(Paths.get("./module1"))
+    sensorContext.setFileSystem(filesystem)
+
+    // setup the filesystem
+    val testFileA = TestInputFileBuilder
+      .create("module1", "src/main/scala/com/mwz/sonar/scala/scapegoat/TestFileA.scala")
+      .setLanguage("scala")
+      .setType(InputFile.Type.MAIN)
+      .setLines(2)
+      .setOriginalLineOffsets(Array(0, 51)) // line 1 -> 50 chars, line 2 -> 80 chars
+      .setLastValidOffset(131)
+      .build()
+    sensorContext.fileSystem.add(testFileA)
+
+    // setup the active rules
+    val activeRulesBuilder = new ActiveRulesBuilder()
+
+    val emptyClassRuleKey =
+      RuleKey.of("sonar-scala-scapegoat", "Empty case class")
+    activeRulesBuilder
+      .create(emptyClassRuleKey)
+      .setInternalKey("com.sksamuel.scapegoat.inspections.EmptyCaseClass")
+      .activate()
+
+    sensorContext.setActiveRules(activeRulesBuilder.build())
+
+    // set the scapegoat report path property
+    sensorContext.setSettings(
+      new MapSettings()
+        .setProperty("sonar.scala.scapegoat.reportPath", "scapegoat-report/one-file-one-warning.xml")
+    )
+
+    // execute the sensor
+    scapegoatSensor.execute(sensorContext)
+
+    // validate the sensor behavior
+    val testFileAIssueEmptyCaseClass =
+      new DefaultIssue().forRule(emptyClassRuleKey)
+    testFileAIssueEmptyCaseClass.at(
+      testFileAIssueEmptyCaseClass
+        .newLocation()
+        .on(testFileA)
+        .at(new DefaultTextRange(new DefaultTextPointer(1, 0), new DefaultTextPointer(1, 50)))
+        .message(
+          "Empty case class\nEmpty case class can be rewritten as a case object"
+        )
+    )
+
+    sensorContext.allIssues should contain theSameElementsAs Seq(
+      testFileAIssueEmptyCaseClass
+    )
+  }
 }
 
 /** Mock of the ScapegoatReportParser */
@@ -371,6 +443,18 @@ final class TestScapegoatReportParser extends ScapegoatReportParserAPI {
     case "scapegoat-report/no-warnings.xml" =>
       Map()
     case "scapegoat-report/one-file-one-warning.xml" =>
+      Map(
+        "com/mwz/sonar/scala/scapegoat/TestFileA.scala" -> Seq(
+          ScapegoatIssue(
+            line = 1,
+            text = "Empty case class",
+            snippet = "Empty case class can be rewritten as a case object",
+            file = "com/mwz/sonar/scala/scapegoat/TestFileA.scala",
+            inspectionId = "com.sksamuel.scapegoat.inspections.EmptyCaseClass"
+          )
+        )
+      )
+    case "module1/scapegoat-report/one-file-one-warning.xml" =>
       Map(
         "com/mwz/sonar/scala/scapegoat/TestFileA.scala" -> Seq(
           ScapegoatIssue(

--- a/src/test/scala/com/mwz/sonar/scala/scoverage/ScoverageSensorSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scoverage/ScoverageSensorSpec.scala
@@ -21,8 +21,8 @@ package scoverage
 
 import java.nio.file.{Path, Paths}
 
-import com.mwz.sonar.scala.util.PathUtils
-import org.scalatest.{FlatSpec, LoneElement, Matchers}
+import com.mwz.sonar.scala.util.PathUtils._
+import org.scalatest.{FlatSpec, LoneElement}
 import org.sonar.api.batch.fs.InputFile
 import org.sonar.api.batch.fs.internal.{DefaultFileSystem, TestInputFileBuilder}
 import org.sonar.api.batch.sensor.internal.{DefaultSensorDescriptor, SensorContextTester}
@@ -46,7 +46,6 @@ class ScoverageSensorSpec extends FlatSpec with SensorContextMatchers with LoneE
   }
 
   it should "correctly save component scoverage" in {
-    val cwd = PathUtils.cwd
     val context = SensorContextTester.create(cwd)
     val scoverage = Scoverage(123, 15, 88.72, 14.17)
     val mainFile = TestInputFileBuilder
@@ -68,7 +67,6 @@ class ScoverageSensorSpec extends FlatSpec with SensorContextMatchers with LoneE
   }
 
   it should "return all scala files from the module" in {
-    val cwd = PathUtils.cwd
     val context = SensorContextTester.create(cwd)
 
     context.setSettings(new MapSettings().setProperty("sonar.sources", "src/main/scala"))
@@ -103,15 +101,6 @@ class ScoverageSensorSpec extends FlatSpec with SensorContextMatchers with LoneE
 
     val files = scoverageSensor.getModuleSourceFiles(context.fileSystem)
     files.toSeq should contain theSameElementsAs Seq(mainFile, otherFile)
-  }
-
-  it should "get module base directory" in {
-    val cwd = PathUtils.cwd
-
-    scoverageSensor.getModuleBaseDirectory(new DefaultFileSystem(cwd)) shouldBe Paths.get("")
-    scoverageSensor.getModuleBaseDirectory(
-      new DefaultFileSystem(cwd.resolve("module"))
-    ) shouldBe Paths.get("module")
   }
 
   it should "get default scoverage report path" in {
@@ -175,7 +164,6 @@ class ScoverageSensorSpec extends FlatSpec with SensorContextMatchers with LoneE
 
   it should "handle correctly absolute source paths" in {
     // prepare the sensor context
-    val cwd = PathUtils.cwd
     val context = SensorContextTester.create(cwd)
     context.setSettings(
       new MapSettings().setProperty(

--- a/src/test/scala/com/mwz/sonar/scala/util/PathUtilsTest.scala
+++ b/src/test/scala/com/mwz/sonar/scala/util/PathUtilsTest.scala
@@ -1,12 +1,12 @@
 package com.mwz.sonar.scala.util
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.Paths
 
+import com.mwz.sonar.scala.util.PathUtils._
 import org.scalatest.{FlatSpec, Matchers}
+import org.sonar.api.batch.fs.internal.DefaultFileSystem
 
 class PathUtilsTest extends FlatSpec with Matchers {
-  val cwd: Path = PathUtils.cwd
-
   "relativize" should "successfully resolve a relative suffix path against a 'next' path" in {
     PathUtils.relativize(
       base = Paths.get("."),
@@ -45,5 +45,12 @@ class PathUtilsTest extends FlatSpec with Matchers {
       prefix = Paths.get("x/y"),
       path = Paths.get("a/b/c")
     ) shouldBe Paths.get("a/b/c")
+  }
+
+  "getModuleBaseDirectory" should "get module base directory" in {
+    getModuleBaseDirectory(new DefaultFileSystem(cwd)) shouldBe Paths.get("")
+    getModuleBaseDirectory(
+      new DefaultFileSystem(cwd.resolve("module"))
+    ) shouldBe Paths.get("module")
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "6.6.0-SNAPSHOT"
+version in ThisBuild := "6.5.1-SNAPSHOT"


### PR DESCRIPTION
This PR fixes the Scapegoat sensor issue with multi-module projects where the report from the root module was used for each submodule. The fix was to resolve each report path relative to the working directory including the module directory when the sensor gets executed.

This fixes #92.

Hi @BalmungSan 👋, would you be able to review this PR?