### PR TITLE
Scalastyle rules repository

### DIFF
--- a/project/src/main/scala/ScalastyleInspectionsGenerator.scala
+++ b/project/src/main/scala/ScalastyleInspectionsGenerator.scala
@@ -117,8 +117,7 @@ object ScalastyleInspectionsGenerator {
   def transform(source: Tree, inspections: Seq[ScalastyleInspection]): Tree = {
     val stringified: Seq[String] = inspections.collect {
       case inspection =>
-        // TODO: Do we want to format the text with code examples?
-        // TODO: Is there a better way of embedding multi-line text?
+        // Is there a better way of embedding multi-line text?
         val extraDescription = inspection.extraDescription.map(s => "\"\"\"" + s + "\"\"\"")
         val justification = inspection.justification.map(s => "\"\"\"" + s + "\"\"\"")
         val params = inspection.params.map { p =>

--- a/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
+++ b/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
@@ -22,6 +22,7 @@ import java.nio.file.{Path, Paths}
 
 import cats.kernel.Eq
 import cats.syntax.eq._
+import com.mwz.sonar.scala.scalastyle.ScalastyleRulesRepository
 import com.mwz.sonar.scala.scapegoat.{
   ScapegoatQualityProfile,
   ScapegoatReportParser,
@@ -31,7 +32,7 @@ import com.mwz.sonar.scala.scapegoat.{
 import com.mwz.sonar.scala.scoverage.{ScoverageMetrics, ScoverageReportParser, ScoverageSensor}
 import com.mwz.sonar.scala.sensor.ScalaSensor
 import com.mwz.sonar.scala.util.JavaOptionals._
-import com.ncredinburgh.sonar.scalastyle.{ScalastyleQualityProfile, ScalastyleRepository, ScalastyleSensor}
+import com.ncredinburgh.sonar.{scalastyle => oldscalastyle}
 import org.sonar.api.Plugin
 import org.sonar.api.config.Configuration
 import org.sonar.api.resources.AbstractLanguage
@@ -117,10 +118,12 @@ final class ScalaPlugin extends Plugin {
       // Scala
       classOf[Scala],
       classOf[ScalaSensor],
+      // Old Scalastyle (ncredinburgh)
+      classOf[oldscalastyle.ScalastyleRepository],
+      classOf[oldscalastyle.ScalastyleQualityProfile],
+      classOf[oldscalastyle.ScalastyleSensor],
       // Scalastyle
-      classOf[ScalastyleRepository],
-      classOf[ScalastyleQualityProfile],
-      classOf[ScalastyleSensor],
+      classOf[ScalastyleRulesRepository],
       // Scoverage
       classOf[ScoverageMetrics],
       classOf[ScoverageReportParser],

--- a/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
+++ b/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
@@ -123,7 +123,7 @@ final class ScalaPlugin extends Plugin {
       classOf[oldscalastyle.ScalastyleQualityProfile],
       classOf[oldscalastyle.ScalastyleSensor],
       // Scalastyle
-      classOf[ScalastyleRulesRepository],
+      // classOf[ScalastyleRulesRepository],
       // Scoverage
       classOf[ScoverageMetrics],
       classOf[ScoverageReportParser],

--- a/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
+++ b/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
@@ -22,15 +22,6 @@ import java.nio.file.{Path, Paths}
 
 import cats.kernel.Eq
 import cats.syntax.eq._
-import com.mwz.sonar.scala.scalastyle.ScalastyleRulesRepository
-import com.mwz.sonar.scala.scapegoat.{
-  ScapegoatQualityProfile,
-  ScapegoatReportParser,
-  ScapegoatRulesRepository,
-  ScapegoatSensor
-}
-import com.mwz.sonar.scala.scoverage.{ScoverageMetrics, ScoverageReportParser, ScoverageSensor}
-import com.mwz.sonar.scala.sensor.ScalaSensor
 import com.mwz.sonar.scala.util.JavaOptionals._
 import com.ncredinburgh.sonar.{scalastyle => oldscalastyle}
 import org.sonar.api.Plugin
@@ -117,22 +108,22 @@ final class ScalaPlugin extends Plugin {
     context.addExtensions(
       // Scala
       classOf[Scala],
-      classOf[ScalaSensor],
+      classOf[sensor.ScalaSensor],
       // Old Scalastyle (ncredinburgh)
       classOf[oldscalastyle.ScalastyleRepository],
       classOf[oldscalastyle.ScalastyleQualityProfile],
       classOf[oldscalastyle.ScalastyleSensor],
       // Scalastyle
-      // classOf[ScalastyleRulesRepository],
+      // classOf[scalastyle.ScalastyleRulesRepository],
       // Scoverage
-      classOf[ScoverageMetrics],
-      classOf[ScoverageReportParser],
-      classOf[ScoverageSensor],
+      classOf[scoverage.ScoverageMetrics],
+      classOf[scoverage.ScoverageReportParser],
+      classOf[scoverage.ScoverageSensor],
       // Scapegoat
-      classOf[ScapegoatRulesRepository],
-      classOf[ScapegoatQualityProfile],
-      classOf[ScapegoatReportParser],
-      classOf[ScapegoatSensor]
+      classOf[scapegoat.ScapegoatRulesRepository],
+      classOf[scapegoat.ScapegoatQualityProfile],
+      classOf[scapegoat.ScapegoatReportParser],
+      classOf[scapegoat.ScapegoatSensor]
     )
   }
 }

--- a/src/main/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepository.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepository.scala
@@ -1,0 +1,145 @@
+/*
+ * Sonar Scala Plugin
+ * Copyright (C) 2018 All contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package com.mwz.sonar.scala
+package scalastyle
+
+import cats.instances.string._
+import cats.syntax.option._
+import org.scalastyle._
+import org.sonar.api.batch.rule.Severity
+import org.sonar.api.rule.RuleStatus
+import org.sonar.api.rules.RuleType
+import org.sonar.api.server.rule.{RuleParamType, RulesDefinition}
+
+/**
+ * Defines a repository for the Scalastyle inspections.
+ */
+final class ScalastyleRulesRepository extends RulesDefinition {
+  import ScalastyleRulesRepository._
+
+  override def define(context: RulesDefinition.Context): Unit = {
+    // Create an empty repository.
+    val repository = context
+      .createRepository(RepositoryKey, Scala.LanguageKey)
+      .setName(RepositoryName)
+
+    // Register each Scalastyle inspection as a repository rule.
+    ScalastyleInspections.AllInspections.foreach { inspection =>
+      val rule = repository.createRule(inspection.clazz)
+      rule.setInternalKey(inspection.clazz)
+      rule.setName(inspection.label)
+      rule.setMarkdownDescription(formatDescription(inspection))
+      rule.setActivatedByDefault(true) // scalastyle:ignore LiteralArguments
+      rule.setStatus(RuleStatus.READY)
+      rule.setSeverity(levelToSeverity(inspection.defaultLevel).name)
+      rule.setType(RuleType.CODE_SMELL)
+
+      // Create parameters.
+      inspection.params.foreach { param =>
+        rule
+          .createParam(param.name)
+          .setType(parameterTypeToRuleParamType(param.typ))
+          .setDescription(s"${param.label}: ${param.description}")
+          .setDefaultValue(param.default)
+      }
+
+      // Set the rule as a template if it contains parameters.
+      rule.setTemplate(inspection.params.nonEmpty)
+    }
+
+    // Save the repository.
+    repository.done()
+  }
+}
+
+private[scalastyle] object ScalastyleRulesRepository {
+  private final case class Acc(indent: Boolean, isEmpty: Boolean, text: String)
+
+  final val RepositoryKey = "sonar-scala-scalastyle"
+  final val RepositoryName = "Scalastyle"
+
+  /**
+   * Convert Scalastyle inspection level to SonarQube rule severity.
+   */
+  def levelToSeverity(level: Level): Severity = level match {
+    case InfoLevel    => Severity.INFO
+    case WarningLevel => Severity.MINOR
+    case ErrorLevel   => Severity.MAJOR
+  }
+
+  /**
+   * Convert Scalastyle inspection parameter type to SonarQube rule parameter type.
+   */
+  def parameterTypeToRuleParamType(typ: ParameterType): RuleParamType = typ match {
+    case StringType  => RuleParamType.STRING
+    case IntegerType => RuleParamType.INTEGER
+    case BooleanType => RuleParamType.BOOLEAN
+    // TODO: RuleParamType.TEXT is used for header parameter of the HeaderMatchesChecker inspection - is this necessary?
+  }
+
+  /**
+   * Create a full description for a Scalastyle inspection.
+   */
+  def formatDescription(inspection: ScalastyleInspection): String = {
+    s"*${inspection.description}*" +
+    inspection.justification.map(s => s"\n\n${format(s)}").orEmpty +
+    inspection.extraDescription.map(s => s"\n\n${format(s)}").orEmpty
+  }
+
+  /**
+   * Reformat the text into a markdown format.
+   */
+  def format(s: String): String = {
+    s.lines.foldLeft(Acc(indent = false, isEmpty = true, "")) {
+      case (acc, l) =>
+        // Remove all backslashes as they are unnecessary.
+        val line = l.replace("\\", "")
+        val trailingSpaces = line.takeWhile(_ == ' ').length
+        // Trim the text and replace ` with `` for inline code blocks.
+        val trimmed = line.trim.replace("`", "``")
+
+        acc match {
+          // Empty line.
+          case _ if trimmed.length == 0 =>
+            acc.copy(isEmpty = true)
+
+          // Previous line indented.
+          case Acc(true, _, text) =>
+            if (trailingSpaces <= 2)
+              Acc(indent = false, isEmpty = false, s"$text\n`` $trimmed")
+            else
+              Acc(indent = true, isEmpty = false, s"$text\n$line")
+
+          // Previous line not indented.
+          case Acc(false, isEmpty, text) =>
+            if (trailingSpaces <= 2)
+              if (isEmpty)
+                Acc(indent = false, isEmpty = false, s"$trimmed")
+              else
+                Acc(indent = false, isEmpty = false, s"$text\n$trimmed")
+            else
+              Acc(indent = true, isEmpty = false, s"$text\n``\n$line")
+        }
+    } match {
+      // Close code block.
+      case Acc(true, _, text) => s"$text\n``"
+      case acc                => acc.text
+    }
+  }
+}

--- a/src/main/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepository.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepository.scala
@@ -54,7 +54,7 @@ final class ScalastyleRulesRepository extends RulesDefinition {
       inspection.params.foreach { param =>
         rule
           .createParam(param.name)
-          .setType(parameterTypeToRuleParamType(param.typ))
+          .setType(parameterTypeToRuleParamType(inspection.clazz, param.name, param.typ))
           .setDescription(s"${param.label}: ${param.description}")
           .setDefaultValue(param.default)
       }
@@ -86,12 +86,20 @@ private[scalastyle] object ScalastyleRulesRepository {
   /**
    * Convert Scalastyle inspection parameter type to SonarQube rule parameter type.
    */
-  def parameterTypeToRuleParamType(typ: ParameterType): RuleParamType = typ match {
-    case StringType  => RuleParamType.STRING
-    case IntegerType => RuleParamType.INTEGER
-    case BooleanType => RuleParamType.BOOLEAN
-    // TODO: RuleParamType.TEXT is used for header parameter of the HeaderMatchesChecker inspection - is this necessary?
-  }
+  def parameterTypeToRuleParamType(ruleClass: String, name: String, typ: ParameterType): RuleParamType =
+    typ match {
+      // RuleParamType.TEXT is used for header parameter of the HeaderMatchesChecker inspection.
+      case StringType
+          if ruleClass == "org.scalastyle.file.HeaderMatchesChecker" &&
+          name == "header" =>
+        RuleParamType.TEXT
+      case StringType =>
+        RuleParamType.STRING
+      case IntegerType =>
+        RuleParamType.INTEGER
+      case BooleanType =>
+        RuleParamType.BOOLEAN
+    }
 
   /**
    * Create a full description for a Scalastyle inspection.

--- a/src/main/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepository.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepository.scala
@@ -103,7 +103,7 @@ private[scalastyle] object ScalastyleRulesRepository {
   }
 
   /**
-   * Reformat the text into a markdown format.
+   * Reformat the text from Scalastyle docs into a markdown format.
    */
   def format(s: String): String = {
     s.lines.foldLeft(Acc(indent = false, isEmpty = true, "")) {
@@ -129,9 +129,10 @@ private[scalastyle] object ScalastyleRulesRepository {
           // Previous line not indented.
           case Acc(false, isEmpty, text) =>
             if (trailingSpaces <= 2)
-              if (isEmpty)
-                Acc(indent = false, isEmpty = false, s"$trimmed")
-              else
+              if (isEmpty) {
+                val space = if (text.isEmpty) "" else "\n"
+                Acc(indent = false, isEmpty = false, s"$text$space$trimmed")
+              } else
                 Acc(indent = false, isEmpty = false, s"$text\n$trimmed")
             else
               Acc(indent = true, isEmpty = false, s"$text\n``\n$line")

--- a/src/main/scala/com/ncredinburgh/sonar/scalastyle/Constants.scala
+++ b/src/main/scala/com/ncredinburgh/sonar/scalastyle/Constants.scala
@@ -21,8 +21,8 @@ package com.ncredinburgh.sonar.scalastyle
 object Constants {
   val ScalaKey = "scala"
   val RepositoryKey = "Scalastyle"
-  val RepositoryName = "Scalastyle Rules"
-  val ProfileName = "Scalastyle"
+  val RepositoryName = "Scalastyle (deprecated)"
+  val ProfileName = "Scalastyle (deprecated)"
 
   /** the class of the checker that should be executed by the sonar rule */
   val ClazzParam = "scalastyle-checker"

--- a/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleRepository.scala
+++ b/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleRepository.scala
@@ -78,7 +78,7 @@ final class ScalastyleRepository extends RulesDefinition {
         // if a rule has at least one real parameter make it a template
         rule.setTemplate(repoRule.params.nonEmpty)
 
-        // TODO: Set the status of those rules as deprecated3?
+        // TODO: Set the status of those rules as deprecated?
         // rule.setStatus(RuleStatus.DEPRECATED)
       }
     }

--- a/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleRepository.scala
+++ b/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleRepository.scala
@@ -18,12 +18,13 @@
  */
 package com.ncredinburgh.sonar.scalastyle
 
-import org.sonar.api.rule.Severity
+import org.sonar.api.rule.{RuleStatus, Severity}
 import org.sonar.api.server.rule.RulesDefinition
 import org.sonar.api.server.rule.RuleParamType
 import org.slf4j.LoggerFactory
 import org.sonar.api.server.rule.RulesDefinition.NewRepository
 import com.ncredinburgh.sonar.scalastyle.ScalastyleRepository.getStandardKey
+
 import scala.annotation.tailrec
 
 object ScalastyleRepository {
@@ -76,6 +77,9 @@ final class ScalastyleRepository extends RulesDefinition {
 
         // if a rule has at least one real parameter make it a template
         rule.setTemplate(repoRule.params.nonEmpty)
+
+        // TODO: Set the status of those rules as deprecated3?
+        // rule.setStatus(RuleStatus.DEPRECATED)
       }
     }
 

--- a/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleRepository.scala
+++ b/src/main/scala/com/ncredinburgh/sonar/scalastyle/ScalastyleRepository.scala
@@ -78,7 +78,7 @@ final class ScalastyleRepository extends RulesDefinition {
         // if a rule has at least one real parameter make it a template
         rule.setTemplate(repoRule.params.nonEmpty)
 
-        // TODO: Set the status of those rules as deprecated?
+        // TODO: Set the status of those rules as deprecated upon release of the new module.
         // rule.setStatus(RuleStatus.DEPRECATED)
       }
     }

--- a/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepositoryTest.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepositoryTest.scala
@@ -1,0 +1,82 @@
+/*
+ * Sonar Scala Plugin
+ * Copyright (C) 2018 All contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package com.mwz.sonar.scala
+package scalastyle
+
+import org.scalatest.{FlatSpec, Inspectors, LoneElement, Matchers}
+import org.sonar.api.rule.RuleStatus
+import org.sonar.api.rules.RuleType
+import org.sonar.api.server.rule.RulesDefinition.{Context, Repository}
+
+class ScalastyleRulesRepositoryTest extends FlatSpec with Matchers with Inspectors with LoneElement {
+
+  trait Ctx {
+    val context = new Context()
+    new ScalastyleRulesRepository().define(context)
+    val repository: Repository = context.repositories.loneElement
+  }
+
+  "ScalastyleRulesRepository" should "define rules repository" in new Ctx {
+    context.repositories().size shouldBe 1
+  }
+
+  it should "correctly define repository properties" in new Ctx {
+    repository.key shouldBe ScalastyleRulesRepository.RepositoryKey
+    repository.name shouldBe ScalastyleRulesRepository.RepositoryName
+    repository.language shouldBe Scala.LanguageKey
+  }
+
+  it should "include all Scalastyle inspections" in new Ctx {
+    repository.rules.size shouldBe ScalastyleInspections.AllInspections.size
+  }
+
+  it should "have all rules with non-empty properties" in new Ctx {
+    forEvery(repository.rules) { rule =>
+      rule.key should not be empty
+      rule.internalKey should not be empty
+      rule.name should not be empty
+      rule.markdownDescription should not be empty
+      rule.severity should not be empty
+    }
+  }
+
+  it should "have all rules' keys start with org.scalastyle" in new Ctx {
+    forEvery(repository.rules) { rule =>
+      rule.key should startWith("org.scalastyle")
+    }
+  }
+
+  it should "have all rules activated by default" in new Ctx {
+    forEvery(repository.rules) { rule =>
+      rule.activatedByDefault shouldBe true
+    }
+  }
+
+  it should "have all rules with READY status" in new Ctx {
+    forEvery(repository.rules) { rule =>
+      rule.status shouldBe RuleStatus.READY
+    }
+  }
+
+  it should "have all rules marked as CODE_SMELL" in new Ctx {
+    forEvery(repository.rules) { rule =>
+      rule.`type` shouldBe RuleType.CODE_SMELL
+    }
+  }
+}

--- a/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepositoryTest.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepositoryTest.scala
@@ -48,7 +48,7 @@ class ScalastyleRulesRepositoryTest extends FlatSpec with Matchers with Inspecto
   }
 
   it should "include all Scalastyle inspections" in new Ctx {
-    repository.rules.size should be > 0
+    ScalastyleInspections.AllInspections.size shouldBe 69
     repository.rules.size shouldBe ScalastyleInspections.AllInspections.size
   }
 
@@ -124,9 +124,14 @@ class ScalastyleRulesRepositoryTest extends FlatSpec with Matchers with Inspecto
   }
 
   it should "convert Scalastyle parameter type to SonarQube parameter type" in {
-    ScalastyleRulesRepository.parameterTypeToRuleParamType(StringType) shouldBe RuleParamType.STRING
-    ScalastyleRulesRepository.parameterTypeToRuleParamType(IntegerType) shouldBe RuleParamType.INTEGER
-    ScalastyleRulesRepository.parameterTypeToRuleParamType(BooleanType) shouldBe RuleParamType.BOOLEAN
+    ScalastyleRulesRepository.parameterTypeToRuleParamType(
+      "org.scalastyle.file.HeaderMatchesChecker",
+      "header",
+      StringType
+    ) shouldBe RuleParamType.TEXT
+    ScalastyleRulesRepository.parameterTypeToRuleParamType("", "", StringType) shouldBe RuleParamType.STRING
+    ScalastyleRulesRepository.parameterTypeToRuleParamType("", "", IntegerType) shouldBe RuleParamType.INTEGER
+    ScalastyleRulesRepository.parameterTypeToRuleParamType("", "", BooleanType) shouldBe RuleParamType.BOOLEAN
   }
 
   it should "compose the full description from description, justification and extraDescription fields" in {

--- a/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepositoryTest.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepositoryTest.scala
@@ -40,9 +40,9 @@ class ScalastyleRulesRepositoryTest extends FlatSpec with Matchers with Inspecto
   }
 
   it should "correctly define repository properties" in new Ctx {
-    repository.key shouldBe ScalastyleRulesRepository.RepositoryKey
-    repository.name shouldBe ScalastyleRulesRepository.RepositoryName
-    repository.language shouldBe Scala.LanguageKey
+    repository.key shouldBe "sonar-scala-scalastyle"
+    repository.name shouldBe "Scalastyle"
+    repository.language shouldBe "scala"
   }
 
   it should "include all Scalastyle inspections" in new Ctx {


### PR DESCRIPTION
A new Scalastyle rules repository with inspections introduced in #101.

I also added description formatting, which was necessary to make the text look good in the UI - I'll attach some screenshots later. I've decided to go for markdown as it was easier to implement than html markup.

Unfortunately, a few inspections are formatted inconsistently in the `scalastyle_documentation.xml` file which results in the text being rendered differently from the majority, but this is also an issue with the existing Scalastyle module and I'm planning to fix this separately in the upstream Scalastyle project, e.g. the [NonASCIICharacterChecker](https://sonar.sonar-scala.com/coding_rules#rule_key=Scalastyle%3Ascalastyle_NonASCIICharacterChecker) formats the whole text as a code snippet because the text is indented too much compared to the other text. (I'll raise a separate issue for this.)

Relates to #35.