### PR TITLE
WIP Default Scalastyle quality profile.

### DIFF
--- a/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
+++ b/src/main/scala/com/mwz/sonar/scala/ScalaPlugin.scala
@@ -115,6 +115,7 @@ final class ScalaPlugin extends Plugin {
       classOf[oldscalastyle.ScalastyleSensor],
       // Scalastyle
       // classOf[scalastyle.ScalastyleRulesRepository],
+      // classOf[scalastyle.ScalastyleQualityProfile],
       // Scoverage
       classOf[scoverage.ScoverageMetrics],
       classOf[scoverage.ScoverageReportParser],

--- a/src/main/scala/com/mwz/sonar/scala/scalastyle/ScalastyleQualityProfile.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scalastyle/ScalastyleQualityProfile.scala
@@ -1,0 +1,55 @@
+/*
+ * Sonar Scala Plugin
+ * Copyright (C) 2018 All contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+package com.mwz.sonar.scala
+package scalastyle
+
+import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition
+import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition.NewBuiltInQualityProfile
+
+/**
+ * Defines a Scalastyle quality profile.
+ */
+class ScalastyleQualityProfile extends BuiltInQualityProfilesDefinition {
+  import ScalastyleQualityProfile._
+
+  override def define(context: BuiltInQualityProfilesDefinition.Context): Unit = {
+    // Create an empty profile.
+    val profile = context.createBuiltInQualityProfile(ProfileName, Scala.LanguageKey)
+
+    // Ensure this is not the default profile.
+    profile.setDefault(false)
+
+    // Activate all rules in the Scalastyle rules repository.
+    // (except for those which were not included in the repository)
+    ScalastyleInspections.AllInspections
+      .filterNot(i => ScalastyleRulesRepository.SkipTemplateInstances.contains(i.id))
+      .foreach(i => activate(profile, i.clazz))
+
+    // Save the profile.
+    profile.done()
+  }
+
+  private[scalastyle] def activate(profile: NewBuiltInQualityProfile, name: String): Unit =
+    profile.activateRule(ScalastyleRulesRepository.RepositoryKey, name)
+}
+
+private[scalastyle] object ScalastyleQualityProfile {
+  final val ProfileName = "Scalastyle"
+}

--- a/src/main/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepository.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepository.scala
@@ -25,6 +25,7 @@ import org.scalastyle._
 import org.sonar.api.batch.rule.Severity
 import org.sonar.api.rule.RuleStatus
 import org.sonar.api.rules.RuleType
+import org.sonar.api.server.rule.RulesDefinition.{NewParam, NewRepository, NewRule}
 import org.sonar.api.server.rule.{RuleParamType, RulesDefinition}
 
 /**
@@ -41,26 +42,12 @@ final class ScalastyleRulesRepository extends RulesDefinition {
 
     // Register each Scalastyle inspection as a repository rule.
     ScalastyleInspections.AllInspections.foreach { inspection =>
-      val rule = repository.createRule(inspection.clazz)
-      rule.setInternalKey(inspection.clazz)
-      rule.setName(inspection.label)
-      rule.setMarkdownDescription(formatDescription(inspection))
-      rule.setActivatedByDefault(true) // scalastyle:ignore LiteralArguments
-      rule.setStatus(RuleStatus.READY)
-      rule.setSeverity(levelToSeverity(inspection.defaultLevel).name)
-      rule.setType(RuleType.CODE_SMELL)
+      createRule(repository, inspection, template = inspection.params.nonEmpty)
 
-      // Create parameters.
-      inspection.params.foreach { param =>
-        rule
-          .createParam(param.name)
-          .setType(parameterTypeToRuleParamType(inspection.clazz, param.name, param.typ))
-          .setDescription(s"${param.label}: ${param.description}")
-          .setDefaultValue(param.default)
-      }
-
-      // Set the rule as a template if it contains parameters.
-      rule.setTemplate(inspection.params.nonEmpty)
+      // For each template create a rule with default parameter values.
+      // (except for the rules listed in the SkipTemplateInstances set)
+      if (inspection.params.nonEmpty && !SkipTemplateInstances.contains(inspection.id))
+        createRule(repository, inspection, template = false)
     }
 
     // Save the repository.
@@ -73,6 +60,43 @@ private[scalastyle] object ScalastyleRulesRepository {
 
   final val RepositoryKey = "sonar-scala-scalastyle"
   final val RepositoryName = "Scalastyle"
+
+  // Skip creating template instances for the following inspections:
+  // header.matches - this rule wouldn't work with a default parameter value.
+  // regex - no default regex provided.
+  final val SkipTemplateInstances = Set("header.matches", "regex")
+
+  /**
+   * Create a new rule from the given inspection.
+   */
+  def createRule(repository: NewRepository, inspection: ScalastyleInspection, template: Boolean): NewRule = {
+    val key = if (template) s"${inspection.clazz}-template" else inspection.clazz
+    val rule = repository.createRule(key)
+    rule.setInternalKey(key)
+    rule.setName(inspection.label)
+    rule.setMarkdownDescription(formatDescription(inspection))
+    rule.setActivatedByDefault(true) // scalastyle:ignore LiteralArguments
+    rule.setStatus(RuleStatus.READY)
+    rule.setSeverity(levelToSeverity(inspection.defaultLevel).name)
+    rule.setType(RuleType.CODE_SMELL)
+
+    // Create parameters.
+    inspection.params.foreach(createParam(inspection.clazz, rule, _))
+
+    // Set the rule as a template.
+    rule.setTemplate(template)
+  }
+
+  /**
+   * Create the parameter for the given rule.
+   */
+  def createParam(inspectionId: String, rule: NewRule, param: Param): NewParam = {
+    rule
+      .createParam(param.name)
+      .setType(parameterTypeToRuleParamType(inspectionId, param.name, param.typ))
+      .setDescription(s"${param.label}: ${param.description}")
+      .setDefaultValue(param.default)
+  }
 
   /**
    * Convert Scalastyle inspection level to SonarQube rule severity.


### PR DESCRIPTION
As always, I'm opening this for an early feedback as I write new/fix the existing tests.

The main noticeable difference from the existing Scalastyle quality profile is that the rule templates are now created with a key that has the suffix `-template` and each template also has a corresponding rule created with its default parameters, except for the rules which don't make sense with default parameters, e.g.:
- **Match Header** `header.matches` - has an empty string as the default parameter, which wouldn't make the rule to match any text,
- **Regular expression** (`regex`) - again, this template has an empty regex expression which would be pointless to activate.

I'll go over the rules once again to make sure there are no other templates for which we don't want to create default rules.

Relates to #35.