### PR TITLE
WIP Refactor scapegoat inspections generator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import com.mwz.sonar.scala.scapegoat.ScapegoatInspectionsGenerator
 import org.sonar.updatecenter.common.PluginManifest
 import sbt._
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,7 +3,7 @@ libraryDependencies ++= Seq(
   "org.sonarsource.update-center" % "sonar-update-center-common" % "1.21.0.561",
   // Scapegoat & scalastyle inspections generator dependencies
   "com.sksamuel.scapegoat" %% "scalac-scapegoat-plugin" % "1.3.7",
-  "io.github.lukehutch" % "fast-classpath-scanner" % "3.1.13",
+  "io.github.classgraph" % "classgraph" % "4.1.6",
   "org.scalastyle" %% "scalastyle" % "1.0.0",
   "org.scalameta" %% "scalameta" % "4.0.0-M8",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test

--- a/project/src/main/resources/ScapegoatInspections.scala
+++ b/project/src/main/resources/ScapegoatInspections.scala
@@ -38,7 +38,7 @@ private[scapegoat] object Level {
 private[scapegoat] final case class ScapegoatInspection(
   id: String,
   name: String,
-  description: String,
+  description: Option[String],
   defaultLevel: Level
 )
 

--- a/project/src/main/resources/ScapegoatInspections.scala
+++ b/project/src/main/resources/ScapegoatInspections.scala
@@ -1,0 +1,47 @@
+/*
+ * Sonar Scala Plugin
+ * Copyright (C) 2018 All contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not write to the Free Software Foundation
+ * Inc. 51 Franklin Street Fifth Floor Boston MA 02110-1301 USA.
+ */
+package com.mwz.sonar.scala
+package scapegoat
+
+import org.sonar.api.batch.rule.Severity
+
+private[scapegoat] sealed trait Level {
+  def toRuleSeverity: Severity = this match {
+    case Level.Error   => Severity.MAJOR
+    case Level.Warning => Severity.MINOR
+    case Level.Info    => Severity.INFO
+  }
+}
+
+private[scapegoat] object Level {
+  case object Error extends Level
+  case object Warning extends Level
+  case object Info extends Level
+}
+
+private[scapegoat] final case class ScapegoatInspection(
+  id: String,
+  name: String,
+  description: String,
+  defaultLevel: Level
+)
+
+private[scapegoat] object ScapegoatInspections {
+  val AllInspections: List[ScapegoatInspection] = ???
+}

--- a/project/src/main/scala/ScalastyleInspectionsGenerator.scala
+++ b/project/src/main/scala/ScalastyleInspectionsGenerator.scala
@@ -47,7 +47,7 @@ object ScalastyleInspectionsGenerator {
     // Collect Scalastyle inspections from config files.
     val generatedInspections: Seq[ScalastyleInspection] = extractInspections(inspections, docs, config)
 
-    // Load the template file from ./project/src/main/scala/ScalastyleInspections.scala.
+    // Load the template file.
     val templateFile = Paths
       .get(
         baseDirectory.value.toString,
@@ -57,7 +57,6 @@ object ScalastyleInspectionsGenerator {
         "scala",
         "ScalastyleInspections.scala"
       )
-      .toFile
 
     // Substitute AllInspections with generated inspections.
     val source: Source = templateFile.parse[Source].get

--- a/project/src/main/scala/ScapegoatInspectionsGenerator.scala
+++ b/project/src/main/scala/ScapegoatInspectionsGenerator.scala
@@ -36,7 +36,7 @@ object ScapegoatInspectionsGenerator {
 
   val generatorTask = Def.task {
     val log = streams.value.log
-    log.info("Generating the scapegoat inspections file.")
+    log.info("Generating Scapegoat inspections file.")
 
     // Load the template file.
     val templateFile = Paths
@@ -84,7 +84,7 @@ object ScapegoatInspectionsGenerator {
         s"""ScapegoatInspection(
            |  id = "$inspectionClassName",
            |  name = "${inspection.text}",
-           |  description = "${inspection.explanation.getOrElse("No Explanation")}",
+           |  description = ${inspection.explanation.map(text => s""""$text"""")},
            |  defaultLevel = Level.${inspection.defaultLevel}
            |)""".stripMargin
     }

--- a/project/src/test/scala/ScapegoatInspectionsGeneratorSpec.scala
+++ b/project/src/test/scala/ScapegoatInspectionsGeneratorSpec.scala
@@ -30,7 +30,7 @@ class ScapegoatInspectionsGeneratorSpec extends FlatSpec with LoneElement with M
       """ScapegoatInspection(
         |  id = "com.sksamuel.scapegoat.inspections.AnyUse",
         |  name = "AnyUse",
-        |  description = "No Explanation",
+        |  description = None,
         |  defaultLevel = Level.Info
         |)""".stripMargin
 
@@ -49,19 +49,19 @@ class ScapegoatInspectionsGeneratorSpec extends FlatSpec with LoneElement with M
         """ScapegoatInspection(
           |  id = "com.sksamuel.scapegoat.inspections.AnyUse",
           |  name = "AnyUse",
-          |  description = "No Explanation",
+          |  description = None,
           |  defaultLevel = Level.Info
           |)""".stripMargin,
         """ScapegoatInspection(
           |  id = "com.sksamuel.scapegoat.inspections.EmptyCaseClass",
           |  name = "Empty case class",
-          |  description = "Empty case class can be rewritten as a case object",
+          |  description = Some("Empty case class can be rewritten as a case object"),
           |  defaultLevel = Level.Info
           |)""".stripMargin,
         """ScapegoatInspection(
           |  id = "com.sksamuel.scapegoat.inspections.string.ArraysInFormat",
           |  name = "Array passed to String.format",
-          |  description = "No Explanation",
+          |  description = None,
           |  defaultLevel = Level.Error
           |)""".stripMargin
       )
@@ -84,19 +84,19 @@ class ScapegoatInspectionsGeneratorSpec extends FlatSpec with LoneElement with M
         |    ScapegoatInspection(
         |      id = "com.sksamuel.scapegoat.inspections.AnyUse",
         |      name = "AnyUse",
-        |      description = "No Explanation",
+        |      description = None,
         |      defaultLevel = Level.Info
         |    ),
         |    ScapegoatInspection(
         |      id = "com.sksamuel.scapegoat.inspections.EmptyCaseClass",
         |      name = "Empty case class",
-        |      description = "Empty case class can be rewritten as a case object",
+        |      description = Some("Empty case class can be rewritten as a case object"),
         |      defaultLevel = Level.Info
         |    ),
         |    ScapegoatInspection(
         |      id = "com.sksamuel.scapegoat.inspections.string.ArraysInFormat",
         |      name = "Array passed to String.format",
-        |      description = "No Explanation",
+        |      description = None,
         |      defaultLevel = Level.Error
         |    )
         |  )
@@ -107,19 +107,19 @@ class ScapegoatInspectionsGeneratorSpec extends FlatSpec with LoneElement with M
         """ScapegoatInspection(
           |  id = "com.sksamuel.scapegoat.inspections.AnyUse",
           |  name = "AnyUse",
-          |  description = "No Explanation",
+          |  description = None,
           |  defaultLevel = Level.Info
           |)""".stripMargin,
         """ScapegoatInspection(
           |  id = "com.sksamuel.scapegoat.inspections.EmptyCaseClass",
           |  name = "Empty case class",
-          |  description = "Empty case class can be rewritten as a case object",
+          |  description = Some("Empty case class can be rewritten as a case object"),
           |  defaultLevel = Level.Info
           |)""".stripMargin,
         """ScapegoatInspection(
           |  id = "com.sksamuel.scapegoat.inspections.string.ArraysInFormat",
           |  name = "Array passed to String.format",
-          |  description = "No Explanation",
+          |  description = None,
           |  defaultLevel = Level.Error
           |)""".stripMargin
       )

--- a/project/src/test/scala/ScapegoatInspectionsGeneratorSpec.scala
+++ b/project/src/test/scala/ScapegoatInspectionsGeneratorSpec.scala
@@ -1,0 +1,136 @@
+/*
+ * Sonar Scala Plugin
+ * Copyright (C) 2018 All contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+import com.sksamuel.scapegoat.inspections.{AnyUse, EmptyCaseClass}
+import com.sksamuel.scapegoat.inspections.string.ArraysInFormat
+import org.scalatest.{FlatSpec, LoneElement, Matchers}
+
+import scala.meta._
+
+/** Tests the correct behavior of the Scapegoat Inspections Generator SBT Task */
+class ScapegoatInspectionsGeneratorSpec extends FlatSpec with LoneElement with Matchers {
+  "stringifyInspections" should "correctly format a one scapegoat inspection" in {
+    val expected =
+      """ScapegoatInspection(
+        |  id = "com.sksamuel.scapegoat.inspections.AnyUse",
+        |  name = "AnyUse",
+        |  description = "No Explanation",
+        |  defaultLevel = Level.Info
+        |)""".stripMargin
+
+    val result =
+      ScapegoatInspectionsGenerator
+        .stringifyInspections(
+          List("com.sksamuel.scapegoat.inspections.AnyUse" -> new AnyUse())
+        ).loneElement
+
+    result shouldBe expected
+  }
+
+  "stringifyInspections" should "correctly format a list of scapegoat inspections" in {
+    val expected =
+      List(
+        """ScapegoatInspection(
+          |  id = "com.sksamuel.scapegoat.inspections.AnyUse",
+          |  name = "AnyUse",
+          |  description = "No Explanation",
+          |  defaultLevel = Level.Info
+          |)""".stripMargin,
+        """ScapegoatInspection(
+          |  id = "com.sksamuel.scapegoat.inspections.EmptyCaseClass",
+          |  name = "Empty case class",
+          |  description = "Empty case class can be rewritten as a case object",
+          |  defaultLevel = Level.Info
+          |)""".stripMargin,
+        """ScapegoatInspection(
+          |  id = "com.sksamuel.scapegoat.inspections.string.ArraysInFormat",
+          |  name = "Array passed to String.format",
+          |  description = "No Explanation",
+          |  defaultLevel = Level.Error
+          |)""".stripMargin
+      )
+
+    val result =
+      ScapegoatInspectionsGenerator
+        .stringifyInspections(List(
+          "com.sksamuel.scapegoat.inspections.AnyUse" -> new AnyUse(),
+          "com.sksamuel.scapegoat.inspections.EmptyCaseClass" -> new EmptyCaseClass(),
+          "com.sksamuel.scapegoat.inspections.string.ArraysInFormat" -> new ArraysInFormat()
+        ))
+
+    result shouldBe expected
+  }
+
+  "fillTemplate" should "succesfuly fill the code template with an stringyfied list of inspections" in {
+    val expected =
+      """private[scapegoat] object ScapegoatInspections {
+        |  val AllInspections: List[ScapegoatInspection] = List(
+        |    ScapegoatInspection(
+        |      id = "com.sksamuel.scapegoat.inspections.AnyUse",
+        |      name = "AnyUse",
+        |      description = "No Explanation",
+        |      defaultLevel = Level.Info
+        |    ),
+        |    ScapegoatInspection(
+        |      id = "com.sksamuel.scapegoat.inspections.EmptyCaseClass",
+        |      name = "Empty case class",
+        |      description = "Empty case class can be rewritten as a case object",
+        |      defaultLevel = Level.Info
+        |    ),
+        |    ScapegoatInspection(
+        |      id = "com.sksamuel.scapegoat.inspections.string.ArraysInFormat",
+        |      name = "Array passed to String.format",
+        |      description = "No Explanation",
+        |      defaultLevel = Level.Error
+        |    )
+        |  )
+        |}""".stripMargin
+
+    val stringifiedScapegoatInspections =
+      List(
+        """ScapegoatInspection(
+          |  id = "com.sksamuel.scapegoat.inspections.AnyUse",
+          |  name = "AnyUse",
+          |  description = "No Explanation",
+          |  defaultLevel = Level.Info
+          |)""".stripMargin,
+        """ScapegoatInspection(
+          |  id = "com.sksamuel.scapegoat.inspections.EmptyCaseClass",
+          |  name = "Empty case class",
+          |  description = "Empty case class can be rewritten as a case object",
+          |  defaultLevel = Level.Info
+          |)""".stripMargin,
+        """ScapegoatInspection(
+          |  id = "com.sksamuel.scapegoat.inspections.string.ArraysInFormat",
+          |  name = "Array passed to String.format",
+          |  description = "No Explanation",
+          |  defaultLevel = Level.Error
+          |)""".stripMargin
+      )
+
+    val template =
+      """private[scapegoat] object ScapegoatInspections {
+        |  val AllInspections: List[ScapegoatInspection] = ???
+        |}""".stripMargin
+
+    val result = ScapegoatInspectionsGenerator.fillTemplate(template.parse[Source].get, stringifiedScapegoatInspections)
+
+    result.structure shouldBe expected.parse[Source].get.structure
+  }
+}

--- a/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatQualityProfile.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatQualityProfile.scala
@@ -19,7 +19,6 @@
 package com.mwz.sonar.scala
 package scapegoat
 
-import inspections.ScapegoatInspection.AllScapegoatInspections
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition
 
 /** Defines a quality profile that activates all Scapegoat rules/inspections */
@@ -34,7 +33,7 @@ final class ScapegoatQualityProfile extends BuiltInQualityProfilesDefinition {
     profile.setDefault(false)
 
     // activate each rule in the Scapegoat Rules Repository
-    AllScapegoatInspections foreach { inspection =>
+    ScapegoatInspections.AllInspections.foreach { inspection =>
       profile.activateRule(ScapegoatRulesRepository.RepositoryKey, inspection.id)
     }
 

--- a/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepository.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepository.scala
@@ -19,7 +19,6 @@
 package com.mwz.sonar.scala
 package scapegoat
 
-import com.mwz.sonar.scala.scapegoat.inspections.ScapegoatInspection.AllScapegoatInspections
 import org.sonar.api.rule.RuleStatus
 import org.sonar.api.rules.RuleType
 import org.sonar.api.server.rule.RulesDefinition
@@ -36,7 +35,7 @@ final class ScapegoatRulesRepository extends RulesDefinition {
         .setName(ScapegoatRulesRepository.RepositoryName)
 
     // register each scapegoat inspection as a repository rule
-    AllScapegoatInspections foreach { inspection =>
+    ScapegoatInspections.AllInspections.foreach { inspection =>
       val rule = repository.createRule(inspection.id)
 
       rule.setInternalKey(inspection.id)

--- a/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepository.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepository.scala
@@ -40,7 +40,7 @@ final class ScapegoatRulesRepository extends RulesDefinition {
 
       rule.setInternalKey(inspection.id)
       rule.setName(inspection.name)
-      rule.setMarkdownDescription(inspection.description)
+      rule.setMarkdownDescription(inspection.description.getOrElse("No description"))
       rule.setActivatedByDefault(true) // scalastyle:ignore LiteralArguments
       rule.setStatus(RuleStatus.READY)
       rule.setSeverity(inspection.defaultLevel.toRuleSeverity.name)

--- a/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatSensor.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatSensor.scala
@@ -22,7 +22,6 @@ package scapegoat
 import java.nio.file.{Path, Paths}
 
 import cats.implicits._
-import com.mwz.sonar.scala.scapegoat.inspections.ScapegoatInspection.AllScapegoatInspections
 import com.mwz.sonar.scala.util.JavaOptionals._
 import com.mwz.sonar.scala.util.Log
 import com.mwz.sonar.scala.util.PathUtils._
@@ -131,7 +130,7 @@ final class ScapegoatSensor(scapegoatReportParser: ScapegoatReportParserAPI) ext
                 // check if it is because the rule is not activated in the current quality profile,
                 // or if it is because the inspection does not exist in the scapegoat rules repository
                 val inspectionExists =
-                  AllScapegoatInspections.exists(
+                  ScapegoatInspections.AllInspections.exists(
                     inspection => inspection.id === scapegoatIssue.inspectionId
                   )
                 if (inspectionExists)

--- a/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepositoryTest.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepositoryTest.scala
@@ -38,7 +38,7 @@ class ScalastyleRulesRepositoryTest extends FlatSpec with Matchers with Inspecto
   }
 
   "ScalastyleRulesRepository" should "define rules repository" in new Ctx {
-    context.repositories().size shouldBe 1
+    context.repositories should have size 1
   }
 
   it should "correctly define repository properties" in new Ctx {
@@ -48,8 +48,8 @@ class ScalastyleRulesRepositoryTest extends FlatSpec with Matchers with Inspecto
   }
 
   it should "include all Scalastyle inspections" in new Ctx {
-    ScalastyleInspections.AllInspections.size shouldBe 69
-    repository.rules.size shouldBe ScalastyleInspections.AllInspections.size
+    ScalastyleInspections.AllInspections should have size 69
+    repository.rules should have size ScalastyleInspections.AllInspections.size
   }
 
   it should "have all rules with non-empty properties" in new Ctx {

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatInspectionsSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatInspectionsSpec.scala
@@ -39,7 +39,6 @@ class ScapegoatInspectionsSpec extends FlatSpec with Inspectors with Matchers {
     forEvery(ScapegoatInspections.AllInspections) { inspection =>
       inspection.id should not be empty
       inspection.name should not be empty
-      inspection.description should not be empty
     }
   }
 
@@ -53,7 +52,7 @@ class ScapegoatInspectionsSpec extends FlatSpec with Inspectors with Matchers {
     val anyUseInspection = ScapegoatInspection(
       id = "com.sksamuel.scapegoat.inspections.AnyUse",
       name = "AnyUse",
-      description = "No Explanation",
+      description = None,
       defaultLevel = Level.Info
     )
 

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatInspectionsSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatInspectionsSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Sonar Scala Plugin
+ * Copyright (C) 2018 All contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package com.mwz.sonar.scala.scapegoat
+
+import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.sonar.api.batch.rule.Severity
+
+/** Tests the generated scapegoat inspections file */
+class ScapegoatInspectionsSpec extends FlatSpec with Inspectors with Matchers {
+  "The Scapegoat Inspections object" should "define all scapegoat inspections" in {
+    ScapegoatInspections.AllInspections.length shouldBe 126
+    ScapegoatInspections.AllInspections.distinct.length shouldBe 126
+  }
+
+  it should "not define the blacklisted scapegoat inspections" in {
+    ScapegoatInspections.AllInspections.map(inspection => inspection.id) should contain noneOf (
+      "com.sksamuel.scapegoat.inspections.collections.FilterDotSizeComparison",
+      "com.sksamuel.scapegoat.inspections.collections.ListTail"
+    )
+  }
+
+  it should "have all inspections with non-empty properties" in {
+    forEvery(ScapegoatInspections.AllInspections) { inspection =>
+      inspection.id should not be empty
+      inspection.name should not be empty
+      inspection.description should not be empty
+    }
+  }
+
+  it should "have all inspections' ids start with com.sksamuel.scapegoat.inspections" in {
+    forEvery(ScapegoatInspections.AllInspections) { inspection =>
+      inspection.id should startWith("com.sksamuel.scapegoat.inspections.")
+    }
+  }
+
+  it should "correctly define the AnyUse inspection" in {
+    val anyUseInspection = ScapegoatInspection(
+      id = "com.sksamuel.scapegoat.inspections.AnyUse",
+      name = "AnyUse",
+      description = "No Explanation",
+      defaultLevel = Level.Info
+    )
+
+    ScapegoatInspections.AllInspections should contain(anyUseInspection)
+  }
+
+  "The Scapegoat Inspection Levels" should "correctly map to SonarQube severities" in {
+    Level.Info.toRuleSeverity shouldBe Severity.INFO
+    Level.Warning.toRuleSeverity shouldBe Severity.MINOR
+    Level.Error.toRuleSeverity shouldBe Severity.MAJOR
+  }
+}

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatInspectionsSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatInspectionsSpec.scala
@@ -24,8 +24,8 @@ import org.sonar.api.batch.rule.Severity
 /** Tests the generated scapegoat inspections file */
 class ScapegoatInspectionsSpec extends FlatSpec with Inspectors with Matchers {
   "The Scapegoat Inspections object" should "define all scapegoat inspections" in {
-    ScapegoatInspections.AllInspections.length shouldBe 126
-    ScapegoatInspections.AllInspections.distinct.length shouldBe 126
+    ScapegoatInspections.AllInspections should have size 126
+    ScapegoatInspections.AllInspections.distinct should have size 126
   }
 
   it should "not define the blacklisted scapegoat inspections" in {

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatQualityProfileSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatQualityProfileSpec.scala
@@ -18,8 +18,6 @@
  */
 package com.mwz.sonar.scala.scapegoat
 
-import inspections.ScapegoatInspection
-
 import org.scalatest.{FlatSpec, Inspectors, LoneElement, Matchers}
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition.Context
 
@@ -50,7 +48,7 @@ class ScapegoatQualityProfileSpec extends FlatSpec with Inspectors with LoneElem
 
   it should "activate one rule for each scapegoat inspection" in {
     val scapegoatQualityProfile = context.profilesByLanguageAndName.loneElement.value.loneElement.value
-    val totalInspections = ScapegoatInspection.AllScapegoatInspections.length
+    val totalInspections = ScapegoatInspections.AllInspections.length
 
     scapegoatQualityProfile.rules should have length totalInspections
   }

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatQualityProfileSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatQualityProfileSpec.scala
@@ -23,42 +23,33 @@ import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition.Context
 
 /** Tests the correct behavior of the Scapegoat Quality Profile */
 class ScapegoatQualityProfileSpec extends FlatSpec with Inspectors with LoneElement with Matchers {
-  // tests about properties of the scapegoat quality profile
-  val context = new Context()
-  new ScapegoatQualityProfile().define(context)
-  behavior of "the Scapegoat Quality Profile"
 
-  it should "define only one quality profile" in {
+  trait Ctx {
+    val context = new Context()
+    new ScapegoatQualityProfile().define(context)
+    val qualityProfile = context.profilesByLanguageAndName.loneElement.value.loneElement.value
+    val rules = qualityProfile.rules
+  }
+
+  "ScapegoatQualityProfile" should "define only one quality profile" in new Ctx {
     context.profilesByLanguageAndName should have size 1 // by language
     context.profilesByLanguageAndName.loneElement.value should have size 1 // by language and name
   }
 
-  it should "properly define the properties of the quality profile" in {
-    val scapegoatQualityProfile = context.profilesByLanguageAndName.loneElement.value.loneElement.value
-
-    scapegoatQualityProfile.name shouldBe "Scapegoat"
-    scapegoatQualityProfile.language shouldBe "scala"
+  it should "properly define the properties of the quality profile" in new Ctx {
+    qualityProfile.name shouldBe "Scapegoat"
+    qualityProfile.language shouldBe "scala"
   }
 
-  it should "not be the default quality profile" in {
-    val scapegoatQualityProfile = context.profilesByLanguageAndName.loneElement.value.loneElement.value
-
-    scapegoatQualityProfile should not be 'default
+  it should "not be the default quality profile" in new Ctx {
+    qualityProfile should not be 'default
   }
 
-  it should "activate one rule for each scapegoat inspection" in {
-    val scapegoatQualityProfile = context.profilesByLanguageAndName.loneElement.value.loneElement.value
-    val totalInspections = ScapegoatInspections.AllInspections.length
-
-    scapegoatQualityProfile.rules should have length totalInspections
+  it should "activate one rule for each scapegoat inspection" in new Ctx {
+    qualityProfile.rules should have size ScapegoatInspections.AllInspections.size
   }
 
-  // tests about properties of the scapegoat quality profile
-  val scapegoatQualityProfile = context.profile("scala", "Scapegoat")
-  val rules = scapegoatQualityProfile.rules
-  behavior of "all Scapegoat active Rules"
-
-  it should "be from the Scapegaot Rules Repository" in {
+  "All Scapegoat Active Rules" should "be from the Scapegaot Rules Repository" in new Ctx {
     forEvery(rules) { rule =>
       rule.repoKey shouldBe "sonar-scala-scapegoat"
     }

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepositorySpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepositorySpec.scala
@@ -18,8 +18,6 @@
  */
 package com.mwz.sonar.scala.scapegoat
 
-import inspections.{Level, ScapegoatInspection}
-
 import org.scalatest.{FlatSpec, Inspectors, LoneElement, Matchers}
 import org.sonar.api.server.rule.RulesDefinition.Context
 import org.sonar.api.rule.RuleStatus
@@ -47,7 +45,7 @@ class ScapegoatRulesRepositorySpec extends FlatSpec with Inspectors with LoneEle
 
   it should "define one rule for each scapegoat inspection" in {
     val scapegoatRepository = context.repositories.loneElement
-    val totalInspections = ScapegoatInspection.AllScapegoatInspections.length
+    val totalInspections = ScapegoatInspections.AllInspections.length
 
     scapegoatRepository.rules should have length totalInspections
   }

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepositorySpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepositorySpec.scala
@@ -53,7 +53,7 @@ class ScapegoatRulesRepositorySpec extends FlatSpec with Inspectors with LoneEle
 
     anyUseRule.internalKey shouldBe "com.sksamuel.scapegoat.inspections.AnyUse"
     anyUseRule.name shouldBe "AnyUse"
-    anyUseRule.markdownDescription shouldBe "No Explanation"
+    anyUseRule.markdownDescription shouldBe "No description"
     anyUseRule.activatedByDefault shouldBe true
     anyUseRule.status shouldBe RuleStatus.READY
     anyUseRule.severity shouldBe Severity.INFO

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepositorySpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepositorySpec.scala
@@ -26,33 +26,30 @@ import org.sonar.api.rules.RuleType
 
 /** Tests the correct behavior of the Scapegoat Rules Repository */
 class ScapegoatRulesRepositorySpec extends FlatSpec with Inspectors with LoneElement with Matchers {
-  // tests about properties of the scapegoat repository
-  val context = new Context()
-  new ScapegoatRulesRepository().define(context)
-  behavior of "the Scapegoat Rules Repository"
 
-  it should "define only one repository" in {
-    context.repositories should have length 1
+  trait Ctx {
+    val context = new Context()
+    new ScapegoatRulesRepository().define(context)
+    val repository = context.repositories.loneElement
+    val rules = repository.rules
   }
 
-  it should "properly define the properties of the repository" in {
-    val scapegoatRepository = context.repositories.loneElement
-
-    scapegoatRepository.key shouldBe "sonar-scala-scapegoat"
-    scapegoatRepository.name shouldBe "Scapegoat"
-    scapegoatRepository.language shouldBe "scala"
+  "ScapegoatRulesRepository" should "define only one repository" in new Ctx {
+    context.repositories should have size 1
   }
 
-  it should "define one rule for each scapegoat inspection" in {
-    val scapegoatRepository = context.repositories.loneElement
-    val totalInspections = ScapegoatInspections.AllInspections.length
-
-    scapegoatRepository.rules should have length totalInspections
+  it should "properly define the properties of the repository" in new Ctx {
+    repository.key shouldBe "sonar-scala-scapegoat"
+    repository.name shouldBe "Scapegoat"
+    repository.language shouldBe "scala"
   }
 
-  it should "properly define the properties of the AnyUse rule" in {
-    val scapegoatRepository = context.repositories.loneElement
-    val anyUseRule = scapegoatRepository.rule("com.sksamuel.scapegoat.inspections.AnyUse")
+  it should "define one rule for each scapegoat inspection" in new Ctx {
+    rules should have size ScapegoatInspections.AllInspections.size
+  }
+
+  it should "properly define the properties of the AnyUse rule" in new Ctx {
+    val anyUseRule = repository.rule("com.sksamuel.scapegoat.inspections.AnyUse")
 
     anyUseRule.internalKey shouldBe "com.sksamuel.scapegoat.inspections.AnyUse"
     anyUseRule.name shouldBe "AnyUse"
@@ -63,42 +60,37 @@ class ScapegoatRulesRepositorySpec extends FlatSpec with Inspectors with LoneEle
     anyUseRule.`type` shouldBe RuleType.CODE_SMELL
   }
 
-  // tests about properties of the scapegoat repository rules
-  val scapegoatRepository = context.repository("sonar-scala-scapegoat")
-  val rules = scapegoatRepository.rules
-  behavior of "all Scapegoat Rules"
-
-  it should "have a valid internal key" in {
+  "All Scapegoat Rules" should "have a valid internal key" in new Ctx {
     forEvery(rules) { rule =>
       rule.internalKey should startWith("com.sksamuel.scapegoat.inspections")
     }
   }
 
-  it should "have a non-empty name" in {
+  it should "have a non-empty name" in new Ctx {
     forEvery(rules) { rule =>
       rule.name should not be empty
     }
   }
 
-  it should "have a non-empty description" in {
+  it should "have a non-empty description" in new Ctx {
     forEvery(rules) { rule =>
       rule.markdownDescription should not be empty
     }
   }
 
-  it should "be activated by default" in {
+  it should "be activated by default" in new Ctx {
     forEvery(rules) { rule =>
       rule.activatedByDefault shouldBe true
     }
   }
 
-  it should "have a READY status" in {
+  it should "have a READY status" in new Ctx {
     forEvery(rules) { rule =>
       rule.status shouldBe RuleStatus.READY
     }
   }
 
-  it should "have a valid severity" in {
+  it should "have a valid severity" in new Ctx {
     forEvery(rules) { rule =>
       val ruleSeverity = rule.severity
       forExactly(1, Severity.ALL) { severity =>
@@ -107,7 +99,7 @@ class ScapegoatRulesRepositorySpec extends FlatSpec with Inspectors with LoneEle
     }
   }
 
-  it should "be a CODE_SMELL" in {
+  it should "be a CODE_SMELL" in new Ctx {
     forEvery(rules) { rule =>
       rule.`type` shouldBe RuleType.CODE_SMELL
     }


### PR DESCRIPTION
Fixes #102 

Peding:
- [X] Unit tests.
- [X] PR review feedback.
- [X] Sync with master if #108 gets merged first.

**Important notes:**
I put the ScapegoatInspections.scala file in the _resources_ directory becasue this import `org.sonar.api.batch.rule.Severity`, was making the compilation fail. And I don't really want to add a dependency in the **SonarQubeAPI** to the meta project.

I made everything in the scapegoat inspections file private to the scapegoat package, in favor of my idea of exposing a method in the `QualityProfiles` for creating the **Scapegoat+Scalastyle** quality profile. I'll work on that, after finishing with this.

### Edit
**PS:** I just noticed we have a difference for naming tests classes, I use `SomethingSpec` and you `SomethingTest`, we should stick to one for making the code more consice. I'm happy with any of them, so no problem if you want to change everything to Test.