### PR TITLE
Make Scapegoat sensor work with absolute file paths in the Scapegoat report

### DIFF
--- a/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatReportParser.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatReportParser.scala
@@ -44,7 +44,7 @@ final class ScapegoatReportParser extends ScapegoatReportParserAPI {
           val a = Option(acc).filter(_.nonEmpty).getOrElse("/")
           if (Paths.get(a).toFile.exists)
             Paths.get(a).resolve(s).toString
-          else s"$a.$s"
+          else s"$a.$str"
       }
     } else AllDotsButLastRegex.replaceAllIn(target = path, replacement = "/")
 

--- a/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatReportParser.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatReportParser.scala
@@ -19,8 +19,8 @@
 package com.mwz.sonar.scala.scapegoat
 
 import org.sonar.api.batch.ScannerSide
+import java.nio.file.{Path, Paths}
 
-import java.nio.file.Path
 import scala.xml.XML
 
 trait ScapegoatReportParserAPI {
@@ -32,9 +32,21 @@ trait ScapegoatReportParserAPI {
 final class ScapegoatReportParser extends ScapegoatReportParserAPI {
   private[this] val AllDotsButLastRegex = raw"\.(?=.*\.)".r
 
-  /** Replaces all dots (.) except the last one in a scapegoat path with slashes (/) */
+  /**
+   * Replaces all dots '.' except the last one in a scapegoat path with slashes '/'
+   * while keeping valid directories which contain '.' in their name.
+   */
   private[scapegoat] def replaceAllDotsButLastWithSlashes(path: String): String =
-    AllDotsButLastRegex.replaceAllIn(target = path, replacement = "/")
+    if (path.startsWith(".")) {
+      path.split('.').reduceLeft[String] {
+        case (acc, str) =>
+          val s = Option(str).filter(_.nonEmpty).getOrElse("/")
+          val a = Option(acc).filter(_.nonEmpty).getOrElse("/")
+          if (Paths.get(a).toFile.exists)
+            Paths.get(a).resolve(s).toString
+          else s"$a.$s"
+      }
+    } else AllDotsButLastRegex.replaceAllIn(target = path, replacement = "/")
 
   /** Parses the scapegoat xml report and returns all scapegoat issues by filename */
   override def parse(scapegoatReportPath: Path): Map[String, Seq[ScapegoatIssue]] = {

--- a/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatSensor.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scapegoat/ScapegoatSensor.scala
@@ -98,9 +98,13 @@ final class ScapegoatSensor(scapegoatReportParser: ScapegoatReportParserAPI) ext
 
     scapegoatIssuesByFilename foreach { tuple =>
       val (filename, scapegoatIssues) = tuple
-      log.info(s"Saving the scapegoat issues for file '$filename'.")
+      val relativeFile =
+        if (Paths.get(filename).isAbsolute)
+          context.fileSystem.baseDir.toPath.relativize(Paths.get(filename)).toString
+        else filename
+      log.info(s"Saving the scapegoat issues for file '$relativeFile'.")
 
-      getModuleFile(filename, filesystem) match {
+      getModuleFile(relativeFile, filesystem) match {
         case Some(file) =>
           scapegoatIssues foreach { scapegoatIssue =>
             log.debug(s"Saving the scapegoat issue: $scapegoatIssue.")
@@ -146,7 +150,7 @@ final class ScapegoatSensor(scapegoatReportParser: ScapegoatReportParserAPI) ext
             }
           }
         case None =>
-          log.error(s"The file '$filename' couldn't be found.")
+          log.error(s"The file '$relativeFile' couldn't be found.")
       }
     }
   }

--- a/src/test/scala/com/mwz/sonar/scala/WithFile.scala
+++ b/src/test/scala/com/mwz/sonar/scala/WithFile.scala
@@ -1,0 +1,30 @@
+/*
+ * Sonar Scala Plugin
+ * Copyright (C) 2018 All contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package com.mwz.sonar.scala
+
+import java.io.File
+import java.nio.file.{Files, Path}
+
+trait WithFile {
+  def withFile(path: Path)(test: File => Any): Unit = {
+    val file = Files.createFile(path).toFile
+    try test(file)
+    finally Files.deleteIfExists(path)
+  }
+}

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatReportParserSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatReportParserSpec.scala
@@ -49,14 +49,15 @@ class ScapegoatReportParserSpec extends FlatSpec with Matchers with WithFile {
     linuxPath shouldBe file.toString
   }
 
-  it should "handle correctly multiple dots in path" in withFile(cwd.resolve("example.file.scala")) { file =>
-    val scapegoatPath = file.toString.replace("/", ".")
-    val linuxPath = scapegoatReportParser.replaceAllDotsButLastWithSlashes(scapegoatPath)
+  it should "handle correctly multiple dots in the path" in withFile(cwd.resolve("example..file.scala")) {
+    file =>
+      val scapegoatPath = file.toString.replace("/", ".")
+      val linuxPath = scapegoatReportParser.replaceAllDotsButLastWithSlashes(scapegoatPath)
 
-    linuxPath shouldBe file.toString
+      linuxPath shouldBe file.toString
   }
 
-  it should "be able to parse an empty report" in {
+  "ScapegoatReportParser" should "be able to parse an empty report" in {
     val scapegoatReportPath = Paths.get("src", "test", "resources", "scapegoat", "no-warnings.xml")
     val scapegoatWarnings = scapegoatReportParser.parse(scapegoatReportPath)
 

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatReportParserSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatReportParserSpec.scala
@@ -16,23 +16,31 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package com.mwz.sonar.scala.scapegoat
+package com.mwz.sonar.scala
+package scapegoat
 
-import org.scalatest.{FlatSpec, Matchers}
-
+import java.io.File
 import java.nio.file.Paths
+
+import com.mwz.sonar.scala.util.PathUtils.cwd
+import org.scalatest.{FlatSpec, Matchers}
 
 /** Tests the correct behavior of the Scapegoat XML reports parser */
 class ScapegoatReportParserSpec extends FlatSpec with Matchers {
   val scapegoatReportParser = new ScapegoatReportParser()
 
-  behavior of "the Scapegoat XML Report Parser"
-
-  it should "replace all dots (.) except the last one in a scaegoat path with slashes (/)" in {
+  it should "replace all dots (.) with slashes (/) in a scapegoat path except for the file extension" in {
     val scapegoatPath = "com.mwz.sonar.scala.scapegoat.TestFile.scala"
     val linuxPath = scapegoatReportParser.replaceAllDotsButLastWithSlashes(scapegoatPath)
 
     linuxPath shouldBe "com/mwz/sonar/scala/scapegoat/TestFile.scala"
+  }
+
+  it should "replace all dots (.) with slashes (/) in a scapegoat absolute path except for the file extension" in {
+    val scapegoatPath = cwd.resolve("ScapegoatReportParserSpec.scala").toString.replace("/", ".")
+    val linuxPath = scapegoatReportParser.replaceAllDotsButLastWithSlashes(scapegoatPath)
+
+    linuxPath shouldBe cwd.resolve("ScapegoatReportParserSpec.scala").toString
   }
 
   it should "be able to parse an empty report" in {

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatReportParserSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatReportParserSpec.scala
@@ -19,28 +19,41 @@
 package com.mwz.sonar.scala
 package scapegoat
 
-import java.io.File
 import java.nio.file.Paths
 
 import com.mwz.sonar.scala.util.PathUtils.cwd
 import org.scalatest.{FlatSpec, Matchers}
 
 /** Tests the correct behavior of the Scapegoat XML reports parser */
-class ScapegoatReportParserSpec extends FlatSpec with Matchers {
+class ScapegoatReportParserSpec extends FlatSpec with Matchers with WithFile {
   val scapegoatReportParser = new ScapegoatReportParser()
 
-  it should "replace all dots (.) with slashes (/) in a scapegoat path except for the file extension" in {
+  "replaceAllDotsButLastWithSlashes" should "work with relative paths" in {
     val scapegoatPath = "com.mwz.sonar.scala.scapegoat.TestFile.scala"
     val linuxPath = scapegoatReportParser.replaceAllDotsButLastWithSlashes(scapegoatPath)
 
     linuxPath shouldBe "com/mwz/sonar/scala/scapegoat/TestFile.scala"
   }
 
-  it should "replace all dots (.) with slashes (/) in a scapegoat absolute path except for the file extension" in {
+  it should "work with absolute paths" in {
     val scapegoatPath = cwd.resolve("ScapegoatReportParserSpec.scala").toString.replace("/", ".")
     val linuxPath = scapegoatReportParser.replaceAllDotsButLastWithSlashes(scapegoatPath)
 
     linuxPath shouldBe cwd.resolve("ScapegoatReportParserSpec.scala").toString
+  }
+
+  it should "handle correctly dots in the path" in withFile(cwd.resolve("example.file.scala")) { file =>
+    val scapegoatPath = file.toString.replace("/", ".")
+    val linuxPath = scapegoatReportParser.replaceAllDotsButLastWithSlashes(scapegoatPath)
+
+    linuxPath shouldBe file.toString
+  }
+
+  it should "handle correctly multiple dots in path" in withFile(cwd.resolve("example.file.scala")) { file =>
+    val scapegoatPath = file.toString.replace("/", ".")
+    val linuxPath = scapegoatReportParser.replaceAllDotsButLastWithSlashes(scapegoatPath)
+
+    linuxPath shouldBe file.toString
   }
 
   it should "be able to parse an empty report" in {


### PR DESCRIPTION
I'm missing some unit tests with absolute file paths in the test Scapegoat reports, but I'll add those later if you're happy with this fix @BalmungSan.

@samlin425 you might also be interested in having a look at this.

Fixes #115.