### PR TITLE
Remove trailing commas, which are not handled correctly by scalariform.

### DIFF
--- a/src/main/scala/com/mwz/sonar/scala/scoverage/ScoverageMetrics.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scoverage/ScoverageMetrics.scala
@@ -70,7 +70,7 @@ object ScoverageMetrics {
       metricType = Metric.ValueType.INT,
       metricDescription = "Number of all statements",
       metricDirection = Metric.DIRECTION_BETTER,
-      metricDomain = CoreMetrics.DOMAIN_SIZE,
+      metricDomain = CoreMetrics.DOMAIN_SIZE
     )
 
   val coveredStatements: Metric[java.lang.Integer] =
@@ -80,7 +80,7 @@ object ScoverageMetrics {
       metricType = Metric.ValueType.INT,
       metricDescription = "Number of statements covered by tests",
       metricDirection = Metric.DIRECTION_BETTER,
-      metricDomain = CoreMetrics.DOMAIN_SIZE,
+      metricDomain = CoreMetrics.DOMAIN_SIZE
     )
 
   val statementCoverage: Metric[java.lang.Double] =


### PR DESCRIPTION
Having trailing commas in the code causes Scalastyle to return the following error: `illegal start of simple expression: Token(RPAREN,),xxx,))`.

See https://github.com/scala-ide/scalariform/pull/262 for the reference.