### PR TITLE
Use ScapegoatConfig.inspections instead of ClassGraph to populate active Scapegoat inspections

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,7 +3,6 @@ libraryDependencies ++= Seq(
   "org.sonarsource.update-center" % "sonar-update-center-common" % "1.21.0.561",
   // Scapegoat & scalastyle inspections generator dependencies
   "com.sksamuel.scapegoat" %% "scalac-scapegoat-plugin" % "1.3.8",
-  "io.github.classgraph"   % "classgraph"               % "4.4.12",
   "org.scalastyle"         %% "scalastyle"              % "1.0.0",
   "org.scalameta"          %% "scalameta"               % "4.0.0",
   "org.scalatest"          %% "scalatest"               % "3.0.5" % Test

--- a/project/src/main/scala/ScapegoatInspectionsGenerator.scala
+++ b/project/src/main/scala/ScapegoatInspectionsGenerator.scala
@@ -16,30 +16,26 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-import java.nio.file.Paths
-import com.sksamuel.scapegoat.Inspection
-import io.github.classgraph.ClassGraph
+import java.nio.file.{Path, Paths}
+
+import com.sksamuel.scapegoat.{Inspection, ScapegoatConfig}
 import sbt.Keys._
 import sbt._
 
 import scala.meta._
-import scala.collection.JavaConverters._
 
 /** SBT Task that generates a managed file with all scapegoat inspections */
 object ScapegoatInspectionsGenerator {
 
   /** Scapegoat inspections that won't be included in the generated file */
-  val BlacklistedInspections = Set(
-    "com.sksamuel.scapegoat.inspections.collections.FilterDotSizeComparison", // Not implemented yet
-    "com.sksamuel.scapegoat.inspections.collections.ListTail" // Not implemented yet
-  )
+  val BlacklistedInspections: Set[String] = Set.empty
 
   val generatorTask = Def.task {
     val log = streams.value.log
     log.info("Generating Scapegoat inspections file.")
 
     // Load the template file.
-    val templateFile = Paths
+    val templateFile: Path = Paths
       .get(
         baseDirectory.value.toString,
         "project",
@@ -49,33 +45,24 @@ object ScapegoatInspectionsGenerator {
         "ScapegoatInspections.scala"
       )
 
-    val allScapegoatInspections = extractInspections()
-    val stringifiedScapegoatIsnpections = stringifyInspections(allScapegoatInspections)
-    val transformed = fillTemplate(templateFile.parse[Source].get, stringifiedScapegoatIsnpections)
+    val allScapegoatInspections: List[(String, Inspection)] = extractInspections()
+    val stringifiedScapegoatIsnpections: List[String] = stringifyInspections(allScapegoatInspections)
+    val transformed: Tree = fillTemplate(templateFile.parse[Source].get, stringifiedScapegoatIsnpections)
 
-    val scapegoatInspectionsFile = (sourceManaged in Compile).value / "scapegoat" / "inspections.scala"
+    val scapegoatInspectionsFile: File = (sourceManaged in Compile).value / "scapegoat" / "inspections.scala"
     IO.write(scapegoatInspectionsFile, transformed.syntax)
 
     Seq(scapegoatInspectionsFile)
   }
 
-  /** Returns all scapegoat inspections, except the ones that should be ignored */
+  /**
+   * Returns all scapegoat inspections, except the ones that should be ignored
+   */
   def extractInspections(): List[(String, Inspection)] =
-    // We need to override the scanner class loader,
-    // so it can cast the loaded classes
-    // from class[_] to class[Inspection]
-    new ClassGraph()
-      .overrideClassLoaders(classOf[Inspection].getClassLoader)
-      .whitelistPackages("com.sksamuel.scapegoat.inspections")
-      .scan()
-      .getSubclasses("com.sksamuel.scapegoat.Inspection")
-      .loadClasses(classOf[Inspection])
-      .asScala
-      .toList
-      .collect {
-        case clazz if !BlacklistedInspections.contains(clazz.getName) =>
-          (clazz.getName, clazz.newInstance())
-      }
+    ScapegoatConfig.inspections.collect {
+      case inspection if !BlacklistedInspections.contains(inspection.getClass.getName) =>
+        (inspection.getClass.getName, inspection)
+    }.toList
 
   /** Stringifies a list of scapegoat inspections */
   def stringifyInspections(scapegoatInspections: List[(String, Inspection)]): List[String] =

--- a/project/src/main/scala/ScapegoatInspectionsGenerator.scala
+++ b/project/src/main/scala/ScapegoatInspectionsGenerator.scala
@@ -58,7 +58,7 @@ object ScapegoatInspectionsGenerator {
   def extractInspections(): Seq[(String, Inspection)] =
     ScapegoatConfig.inspections.map { inspection =>
       (inspection.getClass.getName, inspection)
-    }.toList
+    }
 
   /** Stringifies a list of scapegoat inspections */
   def stringifyInspections(scapegoatInspections: Seq[(String, Inspection)]): Seq[String] =

--- a/src/test/scala/com/mwz/sonar/scala/qualityprofiles/RecommendedQualityProfileSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/qualityprofiles/RecommendedQualityProfileSpec.scala
@@ -51,8 +51,8 @@ class RecommendedQualityProfileSpec
     qualityProfile.isDefault shouldBe true
   }
 
-  it should "have 184 rules" in new Ctx {
-    rules.size shouldBe 184 // 61 from Scalastyle + 123 from Scapegoat
+  it should "have 175 rules" in new Ctx {
+    rules.size shouldBe 175 // 61 from Scalastyle + 114 from Scapegoat
   }
 
   it should "have all rules come from either the Scalastyle or the Scapegoat rules repositories" in new Ctx {

--- a/src/test/scala/com/mwz/sonar/scala/qualityprofiles/ScalastyleScapegoatQualityProfileSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/qualityprofiles/ScalastyleScapegoatQualityProfileSpec.scala
@@ -47,7 +47,7 @@ class ScalastyleScapegoatQualityProfileSpec extends FlatSpec with Inspectors wit
   }
 
   it should "define all Scalastyle + Scapegoat rules" in new Ctx {
-    qualityProfile.rules should have size 191 // 65 from Scalastyle + 126 from Scapegoat
+    qualityProfile.rules should have size 182 // 65 from Scalastyle + 117 from Scapegoat
   }
 
   it should "have all rules come from either the Scalastyle or the Scapegaot rules repositories" in new Ctx {

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatInspectionsSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatInspectionsSpec.scala
@@ -24,8 +24,8 @@ import org.sonar.api.batch.rule.Severity
 /** Tests the generated scapegoat inspections file */
 class ScapegoatInspectionsSpec extends FlatSpec with Inspectors with Matchers {
   "The Scapegoat Inspections object" should "define all scapegoat inspections" in {
-    ScapegoatInspections.AllInspections should have size 126
-    ScapegoatInspections.AllInspections.distinct should have size 126
+    ScapegoatInspections.AllInspections should have size 117
+    ScapegoatInspections.AllInspections.distinct should have size 117
   }
 
   it should "not define the blacklisted scapegoat inspections" in {
@@ -48,15 +48,17 @@ class ScapegoatInspectionsSpec extends FlatSpec with Inspectors with Matchers {
     }
   }
 
-  it should "correctly define the AnyUse inspection" in {
-    val anyUseInspection = ScapegoatInspection(
-      id = "com.sksamuel.scapegoat.inspections.AnyUse",
-      name = "AnyUse",
-      description = None,
+  it should "correctly define the ArrayEquals inspection" in {
+    val arrayEquals = ScapegoatInspection(
+      id = "com.sksamuel.scapegoat.inspections.collections.ArrayEquals",
+      name = "Array equals",
+      description = Some(
+        "Array equals is not an equality check. Use a.deep == b.deep or convert to another collection type"
+      ),
       defaultLevel = Level.Info
     )
 
-    ScapegoatInspections.AllInspections should contain(anyUseInspection)
+    ScapegoatInspections.AllInspections should contain(arrayEquals)
   }
 
   "The Scapegoat Inspection Levels" should "correctly map to SonarQube severities" in {

--- a/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepositorySpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scapegoat/ScapegoatRulesRepositorySpec.scala
@@ -19,10 +19,9 @@
 package com.mwz.sonar.scala.scapegoat
 
 import org.scalatest.{FlatSpec, Inspectors, LoneElement, Matchers}
-import org.sonar.api.server.rule.RulesDefinition.Context
-import org.sonar.api.rule.RuleStatus
-import org.sonar.api.rule.Severity
+import org.sonar.api.rule.{RuleStatus, Severity}
 import org.sonar.api.rules.RuleType
+import org.sonar.api.server.rule.RulesDefinition.Context
 
 /** Tests the correct behavior of the Scapegoat Rules Repository */
 class ScapegoatRulesRepositorySpec extends FlatSpec with Inspectors with LoneElement with Matchers {
@@ -48,16 +47,16 @@ class ScapegoatRulesRepositorySpec extends FlatSpec with Inspectors with LoneEle
     rules should have size ScapegoatInspections.AllInspections.size
   }
 
-  it should "properly define the properties of the AnyUse rule" in new Ctx {
-    val anyUseRule = repository.rule("com.sksamuel.scapegoat.inspections.AnyUse")
+  it should "properly define the properties of the ArrayEquals rule" in new Ctx {
+    val arrayEqualsRule = repository.rule("com.sksamuel.scapegoat.inspections.collections.ArrayEquals")
 
-    anyUseRule.internalKey shouldBe "com.sksamuel.scapegoat.inspections.AnyUse"
-    anyUseRule.name shouldBe "AnyUse"
-    anyUseRule.markdownDescription shouldBe "No description"
-    anyUseRule.activatedByDefault shouldBe true
-    anyUseRule.status shouldBe RuleStatus.READY
-    anyUseRule.severity shouldBe Severity.INFO
-    anyUseRule.`type` shouldBe RuleType.CODE_SMELL
+    arrayEqualsRule.internalKey shouldBe "com.sksamuel.scapegoat.inspections.collections.ArrayEquals"
+    arrayEqualsRule.name shouldBe "Array equals"
+    arrayEqualsRule.markdownDescription shouldBe "Array equals is not an equality check. Use a.deep == b.deep or convert to another collection type"
+    arrayEqualsRule.activatedByDefault shouldBe true
+    arrayEqualsRule.status shouldBe RuleStatus.READY
+    arrayEqualsRule.severity shouldBe Severity.INFO
+    arrayEqualsRule.`type` shouldBe RuleType.CODE_SMELL
   }
 
   "All Scapegoat Rules" should "have a valid internal key" in new Ctx {


### PR DESCRIPTION
I didn't realise before that `ScapegoatConfig.inspections` existed, but this way we can obtain the current list of active inspections, without having to blacklist anything (it looks like we were creating 9 rules which are no longer active in Scapegoat). The use of `ClassGraph` is no longer necessary in this case.

Closes #131.