### PR TITLE
Adding Scapegoat & Scalastyle issues to the Maven examples.

### DIFF
--- a/examples/mvn/multi-module/module1/src/main/scala/Example1.scala
+++ b/examples/mvn/multi-module/module1/src/main/scala/Example1.scala
@@ -1,3 +1,18 @@
 object Example1 {
   def sum(a: Int, b: Int) = a + b
+
+  // An example method full of horrible style issues!
+  // This is only indended for demonstration purposes.
+  // Please don't do this at home, because every time
+  // you write code like this, a cute kitten dies!
+  def ExampleIssues: Unit = {
+    val isEmpty = List(1).size == 0
+    val a = (14 / 1).toInt
+    val b = if (true) true else false
+    var TWO = 1 + 1
+    while (true) {
+      println("WOW!")
+    }
+    return ()
+  }
 }

--- a/examples/mvn/multi-module/pom.xml
+++ b/examples/mvn/multi-module/pom.xml
@@ -19,24 +19,32 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <scala.version>2.12.6</scala.version>
+        <scala.version>2.12.8</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <scapegoat.version>1.3.8</scapegoat.version>
 
         <sonar.projectName>[example] Maven Multi Module</sonar.projectName>
         <sonar.sources>src/main/scala</sonar.sources>
         <sonar.tests>src/test/scala</sonar.tests>
         <sonar.junit.reportPaths>target/surefire-reports</sonar.junit.reportPaths>
         <sonar.sourceEncoding>UTF-8</sonar.sourceEncoding>
-        <sonar.scala.version>2.12</sonar.scala.version>
-        <sonar.scala.scoverage.reportPath>target/scoverage.xml</sonar.scala.scoverage.reportPath>
-        <sonar.modukes>module1,module2</sonar.modukes>
+        <sonar.scala.version>${scala.binary.version}</sonar.scala.version>
+        <sonar.scala.scoverage.reportPath>${project.build.directory}/scoverage.xml</sonar.scala.scoverage.reportPath>
+        <sonar.scala.scapegoat.reportPath>${project.build.directory}/scapegoat.xml</sonar.scala.scapegoat.reportPath>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.12</artifactId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
             <version>3.0.5</version>
             <scope>test</scope>
+        </dependency>
+        <!-- To prevent https://github.com/sksamuel/scapegoat/issues/98 -->
+        <dependency>
+            <groupId>com.sksamuel.scapegoat</groupId>
+            <artifactId>scalac-scapegoat-plugin_${scala.binary.version}</artifactId>
+            <version>${scapegoat.version}</version>
         </dependency>
     </dependencies>
 
@@ -46,22 +54,22 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>3.2.2</version>
+                    <version>3.4.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.22.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.scalatest</groupId>
                     <artifactId>scalatest-maven-plugin</artifactId>
-                    <version>1.0</version>
+                    <version>2.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.scoverage</groupId>
@@ -71,7 +79,7 @@
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
-                    <version>3.4.0.905</version>
+                    <version>3.6.0.1398</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -97,6 +105,20 @@
                         </goals>
                     </execution>
                 </executions>
+                <!-- Scapegoat setup -->
+                <configuration>
+                    <args>
+                        <arg>-P:scapegoat:dataDir:${project.build.directory}</arg>
+                        <arg>-P:scapegoat:reports:xml</arg>
+                    </args>
+                    <compilerPlugins>
+                        <compilerPlugin>
+                            <groupId>com.sksamuel.scapegoat</groupId>
+                            <artifactId>scalac-scapegoat-plugin_${scala.binary.version}</artifactId>
+                            <version>${scapegoat.version}</version>
+                        </compilerPlugin>
+                   </compilerPlugins>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -110,8 +132,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/examples/mvn/multi-module/pom.xml
+++ b/examples/mvn/multi-module/pom.xml
@@ -21,7 +21,7 @@
         <java.version>1.8</java.version>
         <scala.version>2.12.8</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <scapegoat.version>1.3.8</scapegoat.version>
+        <scapegoat.version>1.3.6</scapegoat.version>
 
         <sonar.projectName>[example] Maven Multi Module</sonar.projectName>
         <sonar.sources>src/main/scala</sonar.sources>

--- a/examples/mvn/scala-java/pom.xml
+++ b/examples/mvn/scala-java/pom.xml
@@ -15,7 +15,7 @@
         <java.version>1.8</java.version>
         <scala.version>2.12.8</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <scapegoat.version>1.3.8</scapegoat.version>
+        <scapegoat.version>1.3.6</scapegoat.version>
 
         <sonar.projectName>[example] Maven Scala-Java</sonar.projectName>
         <sonar.projectKey>example-mvn-scala-java</sonar.projectKey>

--- a/examples/mvn/scala-java/pom.xml
+++ b/examples/mvn/scala-java/pom.xml
@@ -13,7 +13,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <scala.version>2.12.6</scala.version>
+        <scala.version>2.12.8</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <scapegoat.version>1.3.8</scapegoat.version>
 
         <sonar.projectName>[example] Maven Scala-Java</sonar.projectName>
         <sonar.projectKey>example-mvn-scala-java</sonar.projectKey>
@@ -21,8 +23,9 @@
         <sonar.tests>src/test/scala,src/test/java</sonar.tests>
         <sonar.junit.reportsPath>target/surefire-reports</sonar.junit.reportsPath>
         <sonar.sourceEncoding>UTF-8</sonar.sourceEncoding>
-        <sonar.scala.version>2.12</sonar.scala.version>
+        <sonar.scala.version>${scala.binary.version}</sonar.scala.version>
         <sonar.scala.scoverage.reportPath>target/scoverage.xml</sonar.scala.scoverage.reportPath>
+        <sonar.scala.scapegoat.reportPath>target/scapegoat.xml</sonar.scala.scapegoat.reportPath>
 
         <!-- Sonar Java properties -->
         <sonar.java.binaries>target/scoverage-classes</sonar.java.binaries>
@@ -34,7 +37,7 @@
     <dependencies>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.12</artifactId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
             <version>3.0.5</version>
             <scope>test</scope>
         </dependency>
@@ -44,6 +47,12 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <!-- To prevent https://github.com/sksamuel/scapegoat/issues/98 -->
+        <dependency>
+            <groupId>com.sksamuel.scapegoat</groupId>
+            <artifactId>scalac-scapegoat-plugin_${scala.binary.version}</artifactId>
+            <version>${scapegoat.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -52,22 +61,22 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>3.2.2</version>
+                    <version>3.4.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.22.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.scalatest</groupId>
                     <artifactId>scalatest-maven-plugin</artifactId>
-                    <version>1.0</version>
+                    <version>2.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.scoverage</groupId>
@@ -77,7 +86,7 @@
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
-                    <version>3.4.0.905</version>
+                    <version>3.6.0.1398</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -103,6 +112,20 @@
                         </goals>
                     </execution>
                 </executions>
+                <!-- Scapegoat setup -->
+                <configuration>
+                    <args>
+                        <arg>-P:scapegoat:dataDir:./target</arg>
+                        <arg>-P:scapegoat:reports:xml</arg>
+                    </args>
+                    <compilerPlugins>
+                        <compilerPlugin>
+                            <groupId>com.sksamuel.scapegoat</groupId>
+                            <artifactId>scalac-scapegoat-plugin_${scala.binary.version}</artifactId>
+                            <version>${scapegoat.version}</version>
+                        </compilerPlugin>
+                   </compilerPlugins>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -116,8 +139,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/examples/mvn/scala-java/pom.xml
+++ b/examples/mvn/scala-java/pom.xml
@@ -24,8 +24,8 @@
         <sonar.junit.reportsPath>target/surefire-reports</sonar.junit.reportsPath>
         <sonar.sourceEncoding>UTF-8</sonar.sourceEncoding>
         <sonar.scala.version>${scala.binary.version}</sonar.scala.version>
-        <sonar.scala.scoverage.reportPath>target/scoverage.xml</sonar.scala.scoverage.reportPath>
-        <sonar.scala.scapegoat.reportPath>target/scapegoat.xml</sonar.scala.scapegoat.reportPath>
+        <sonar.scala.scoverage.reportPath>${project.build.directory}/scoverage.xml</sonar.scala.scoverage.reportPath>
+        <sonar.scala.scapegoat.reportPath>${project.build.directory}/scapegoat.xml</sonar.scala.scapegoat.reportPath>
 
         <!-- Sonar Java properties -->
         <sonar.java.binaries>target/scoverage-classes</sonar.java.binaries>
@@ -115,7 +115,7 @@
                 <!-- Scapegoat setup -->
                 <configuration>
                     <args>
-                        <arg>-P:scapegoat:dataDir:./target</arg>
+                        <arg>-P:scapegoat:dataDir:${project.build.directory}</arg>
                         <arg>-P:scapegoat:reports:xml</arg>
                     </args>
                     <compilerPlugins>

--- a/examples/mvn/scala-java/src/main/scala/Example.scala
+++ b/examples/mvn/scala-java/src/main/scala/Example.scala
@@ -1,3 +1,18 @@
 object Example {
   def sum(a: Int, b: Int) = a + b
+
+  // An example method full of horrible style issues!
+  // This is only indended for demonstration purposes.
+  // Please don't do this at home, because every time
+  // you write code like this, a cute kitten dies!
+  def ExampleIssues: Unit = {
+    val isEmpty = List(1).size == 0
+    val a = (14 / 1).toInt
+    val b = if (true) true else false
+    var TWO = 1 + 1
+    while (true) {
+      println("WOW!")
+    }
+    return ()
+  }
 }

--- a/examples/mvn/single-module/pom.xml
+++ b/examples/mvn/single-module/pom.xml
@@ -15,7 +15,7 @@
         <java.version>1.8</java.version>
         <scala.version>2.12.8</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <scapegoat.version>1.3.8</scapegoat.version>
+        <scapegoat.version>1.3.6</scapegoat.version>
 
         <sonar.projectName>[example] Maven Single Module</sonar.projectName>
         <sonar.projectKey>example-mvn-single-module</sonar.projectKey>

--- a/examples/mvn/single-module/pom.xml
+++ b/examples/mvn/single-module/pom.xml
@@ -127,8 +127,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/examples/mvn/single-module/pom.xml
+++ b/examples/mvn/single-module/pom.xml
@@ -24,8 +24,8 @@
         <sonar.junit.reportPaths>target/surefire-reports</sonar.junit.reportPaths>
         <sonar.sourceEncoding>UTF-8</sonar.sourceEncoding>
         <sonar.scala.version>${scala.binary.version}</sonar.scala.version>
-        <sonar.scala.scoverage.reportPath>target/scoverage.xml</sonar.scala.scoverage.reportPath>
-        <sonar.scala.scapegoat.reportPath>target/scapegoat.xml</sonar.scala.scapegoat.reportPath>
+        <sonar.scala.scoverage.reportPath>${project.build.directory}/scoverage.xml</sonar.scala.scoverage.reportPath>
+        <sonar.scala.scapegoat.reportPath>${project.build.directory}/scapegoat.xml</sonar.scala.scapegoat.reportPath>
     </properties>
 
     <dependencies>
@@ -103,7 +103,7 @@
                 <!-- Scapegoat setup -->
                 <configuration>
                     <args>
-                        <arg>-P:scapegoat:dataDir:./target</arg>
+                        <arg>-P:scapegoat:dataDir:${project.build.directory}</arg>
                         <arg>-P:scapegoat:reports:xml</arg>
                     </args>
                     <compilerPlugins>

--- a/examples/mvn/single-module/pom.xml
+++ b/examples/mvn/single-module/pom.xml
@@ -13,7 +13,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <scala.version>2.12.6</scala.version>
+        <scala.version>2.12.8</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <scapegoat.version>1.3.8</scapegoat.version>
 
         <sonar.projectName>[example] Maven Single Module</sonar.projectName>
         <sonar.projectKey>example-mvn-single-module</sonar.projectKey>
@@ -21,16 +23,23 @@
         <sonar.tests>src/test/scala</sonar.tests>
         <sonar.junit.reportPaths>target/surefire-reports</sonar.junit.reportPaths>
         <sonar.sourceEncoding>UTF-8</sonar.sourceEncoding>
-        <sonar.scala.version>2.12</sonar.scala.version>
+        <sonar.scala.version>${scala.binary.version}</sonar.scala.version>
         <sonar.scala.scoverage.reportPath>target/scoverage.xml</sonar.scala.scoverage.reportPath>
+        <sonar.scala.scapegoat.reportPath>target/scapegoat.xml</sonar.scala.scapegoat.reportPath>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.12</artifactId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
             <version>3.0.5</version>
             <scope>test</scope>
+        </dependency>
+        <!-- To prevent https://github.com/sksamuel/scapegoat/issues/98 -->
+        <dependency>
+            <groupId>com.sksamuel.scapegoat</groupId>
+            <artifactId>scalac-scapegoat-plugin_${scala.binary.version}</artifactId>
+            <version>${scapegoat.version}</version>
         </dependency>
     </dependencies>
 
@@ -40,22 +49,22 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>3.2.2</version>
+                    <version>3.4.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.22.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.scalatest</groupId>
                     <artifactId>scalatest-maven-plugin</artifactId>
-                    <version>1.0</version>
+                    <version>2.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.scoverage</groupId>
@@ -65,7 +74,7 @@
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
-                    <version>3.4.0.905</version>
+                    <version>3.6.0.1398</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -91,6 +100,20 @@
                         </goals>
                     </execution>
                 </executions>
+                <!-- Scapegoat setup -->
+                <configuration>
+                    <args>
+                        <arg>-P:scapegoat:dataDir:./target</arg>
+                        <arg>-P:scapegoat:reports:xml</arg>
+                    </args>
+                    <compilerPlugins>
+                        <compilerPlugin>
+                            <groupId>com.sksamuel.scapegoat</groupId>
+                            <artifactId>scalac-scapegoat-plugin_${scala.binary.version}</artifactId>
+                            <version>${scapegoat.version}</version>
+                        </compilerPlugin>
+                   </compilerPlugins>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/examples/mvn/single-module/src/main/scala/Example.scala
+++ b/examples/mvn/single-module/src/main/scala/Example.scala
@@ -1,3 +1,18 @@
 object Example {
   def sum(a: Int, b: Int) = a + b
+
+  // An example method full of horrible style issues!
+  // This is only indended for demonstration purposes.
+  // Please don't do this at home, because every time
+  // you write code like this, a cute kitten dies!
+  def ExampleIssues: Unit = {
+    val isEmpty = List(1).size == 0
+    val a = (14 / 1).toInt
+    val b = if (true) true else false
+    var TWO = 1 + 1
+    while (true) {
+      println("WOW!")
+    }
+    return ()
+  }
 }

--- a/examples/scan.sh
+++ b/examples/scan.sh
@@ -39,4 +39,4 @@ mvn ${SONAR_SCANNER_DEFAULTS} scoverage:report sonar:sonar
 # Maven scala-java
 echo -e "\nScanning Maven scala-java project."
 cd $CWD/mvn/scala-java
-mvn ${SONAR_SCANNER_DEFAULTS} clean test scoverage:report jacoco:report sonar:sonar
+mvn ${SONAR_SCANNER_DEFAULTS} clean test scoverage:report jacoco:report scala:compile sonar:sonar

--- a/examples/scan.sh
+++ b/examples/scan.sh
@@ -29,12 +29,12 @@ gradle --no-daemon ${SONAR_SCANNER_DEFAULTS} clean test reportScoverage sonarqub
 # Maven single-module
 echo -e "\nScanning Maven single-module project."
 cd $CWD/mvn/single-module
-mvn ${SONAR_SCANNER_DEFAULTS} scoverage:report sonar:sonar
+mvn ${SONAR_SCANNER_DEFAULTS} scoverage:report scala:compile sonar:sonar
 
 # Maven multi-module
 echo -e "\nScanning Maven multi-module project."
 cd $CWD/mvn/multi-module
-mvn ${SONAR_SCANNER_DEFAULTS} scoverage:report sonar:sonar
+mvn ${SONAR_SCANNER_DEFAULTS} scoverage:report scala:compile sonar:sonar
 
 # Maven scala-java
 echo -e "\nScanning Maven scala-java project."


### PR DESCRIPTION
Related to #82 & #89.

Ok so, as I said in the Gradle PR, I will use the `1.3.8` version of **Scapegoat** even if that makes the examples to fail.
And we `1.3.9` gets release bump up all in one PR.

If you prefer, we could downgrade it to `1.3.6`.