### PR TITLE
Don’t store module coverage metrics.

### DIFF
--- a/src/main/scala/com/mwz/sonar/scala/scoverage/ScoverageSensor.scala
+++ b/src/main/scala/com/mwz/sonar/scala/scoverage/ScoverageSensor.scala
@@ -65,8 +65,6 @@ final class ScoverageSensor(scoverageReportParser: ScoverageReportParserAPI) ext
         log.info("Successfully loaded the scoverage report file.")
         log.debug(s"Project scoverage information: $projectCoverage.")
 
-        saveComponentScoverage(context, context.module, projectCoverage.projectScoverage)
-
         // Save the coverage information of each file of the project.
         getProjectSourceFiles(filesystem) foreach { file =>
           val filename = PathUtils.cwd.relativize(Paths.get(file.uri())).toString

--- a/src/test/scala/com/mwz/sonar/scala/scoverage/ScoverageSensorSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scoverage/ScoverageSensorSpec.scala
@@ -162,13 +162,6 @@ class ScoverageSensorSpec extends FlatSpec with SensorContextMatchers with LoneE
     // execute the sensor
     scoverageSensor.execute(context)
 
-    // validate the module scoverage metrics
-    val moduleKey = context.module.key
-    context should have(metric[java.lang.Integer](moduleKey, "sonar-scala-scoverage-total-statements", 5))
-    context should have(metric[java.lang.Integer](moduleKey, "sonar-scala-scoverage-covered-statements", 3))
-    context should have(metric[java.lang.Double](moduleKey, "sonar-scala-scoverage-statement-coverage", 60.0))
-    context should have(metric[java.lang.Double](moduleKey, "sonar-scala-scoverage-branch-scoverage", 100.0))
-
     // validate the main file scoverage metrics
     val fileKey = mainFile.key
     context should have(metric[java.lang.Integer](fileKey, "sonar-scala-scoverage-total-statements", 5))
@@ -204,12 +197,12 @@ class ScoverageSensorSpec extends FlatSpec with SensorContextMatchers with LoneE
     // execute the sensor
     scoverageSensor.execute(context)
 
-    //validate the module scoverage metrics
-    val moduleKey = context.module.key
-    context should have(metric[java.lang.Integer](moduleKey, "sonar-scala-scoverage-total-statements", 5))
-    context should have(metric[java.lang.Integer](moduleKey, "sonar-scala-scoverage-covered-statements", 3))
-    context should have(metric[java.lang.Double](moduleKey, "sonar-scala-scoverage-statement-coverage", 60.0))
-    context should have(metric[java.lang.Double](moduleKey, "sonar-scala-scoverage-branch-scoverage", 100.0))
+    // validate the main file scoverage metrics
+    val fileKey = mainFile.key
+    context should have(metric[java.lang.Integer](fileKey, "sonar-scala-scoverage-total-statements", 5))
+    context should have(metric[java.lang.Integer](fileKey, "sonar-scala-scoverage-covered-statements", 3))
+    context should have(metric[java.lang.Double](fileKey, "sonar-scala-scoverage-statement-coverage", 60.0))
+    context should have(metric[java.lang.Double](fileKey, "sonar-scala-scoverage-branch-scoverage", 100.0))
   }
 }
 


### PR DESCRIPTION
> WARN: Storing measures on folders or modules is deprecated. Provided value of metric 'sonar-scala-scoverage-total-statements' is ignored.
> WARN: Storing measures on folders or modules is deprecated. Provided value of metric 'sonar-scala-scoverage-covered-statements' is ignored.
> WARN: Storing measures on folders or modules is deprecated. Provided value of metric 'sonar-scala-scoverage-statement-coverage' is ignored.
> WARN: Storing measures on folders or modules is deprecated. Provided value of metric 'sonar-scala-scoverage-branch-scoverage' is ignored.