### PR TITLE
Upgrade to SonarQube 7.9 LTS (#260) [ci skip]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ sourceGenerators in Compile ++= Seq(
 )
 
 // Lib dependencies
-val sonarVersion = "7.8"
+val sonarVersion = "7.9"
 libraryDependencies ++= List(
   "org.sonarsource.sonarqube" % "sonar-plugin-api" % sonarVersion % Provided,
   "org.slf4j"                 % "slf4j-api"        % "1.7.28" % Provided,

--- a/src/test/scala/com/mwz/sonar/scala/ScalaPluginSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/ScalaPluginSpec.scala
@@ -24,7 +24,7 @@ import org.sonar.api.{Plugin, SonarEdition, SonarQubeSide, SonarRuntime}
 
 class ScalaPluginSpec extends FlatSpec with Matchers {
   val runtime: SonarRuntime = SonarRuntimeImpl.forSonarQube(
-    Version.create(7, 8),
+    Version.create(7, 9),
     SonarQubeSide.SCANNER,
     SonarEdition.COMMUNITY
   )


### PR DESCRIPTION
SonarQube 7.9 is a new LTS release. There are no breaking changes, no new deprecations. The only notable change is that 7.9 requires Java 11 on the server-side, plugins can be still executed using Java 8.