### PR TITLE
Upgrade Scalastyle to 1.1.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ libraryDependencies ++= List(
   "io.circe"                   %% "circe-generic-extras"      % "0.12.2",
   "org.http4s"                 %% "http4s-circe"              % http4s,
   "org.scalariform"            %% "scalariform"               % "0.2.10",
-  "org.scalastyle"             %% "scalastyle"                % "1.0.0",
+  "com.beautiful-scala"        %% "scalastyle"                % "1.1.0",
   "org.scala-lang.modules"     %% "scala-xml"                 % "1.2.0",
   "org.http4s"                 %% "http4s-blaze-server"       % http4s % Test,
   "org.http4s"                 %% "http4s-dsl"                % http4s % Test,

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,7 +3,7 @@ libraryDependencies ++= Seq(
   "org.sonarsource.update-center" % "sonar-update-center-common" % "1.24.0.735",
   // Scapegoat & scalastyle inspections generator dependencies
   "com.sksamuel.scapegoat" %% "scalac-scapegoat-plugin" % "1.3.11",
-  "org.scalastyle"         %% "scalastyle"              % "1.0.0",
+  "com.beautiful-scala"    %% "scalastyle"              % "1.1.0",
   "org.scalameta"          %% "scalameta"               % "4.3.0",
   "org.scalatest"          %% "scalatest"               % "3.1.0" % Test
 )

--- a/project/src/main/scala/ScalastyleInspections.scala
+++ b/project/src/main/scala/ScalastyleInspections.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019  All sonar-scala contributors
+ * Copyright (C) 2018-2020  All sonar-scala contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/project/src/main/scala/ScalastyleInspectionsGenerator.scala
+++ b/project/src/main/scala/ScalastyleInspectionsGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019  All sonar-scala contributors
+ * Copyright (C) 2018-2020  All sonar-scala contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -96,17 +96,16 @@ object ScalastyleInspectionsGenerator {
         val default = param \@ "default"
         Param(name, typ, label, description, default)
       }
-    } yield
-      ScalastyleInspection(
-        clazz,
-        id,
-        label,
-        description,
-        extraDescription,
-        justification,
-        defaultLevel,
-        params
-      )
+    } yield ScalastyleInspection(
+      clazz,
+      id,
+      label,
+      description,
+      extraDescription,
+      justification,
+      defaultLevel,
+      params
+    )
   }
 
   /**
@@ -124,7 +123,7 @@ object ScalastyleInspectionsGenerator {
              |  name = "${p.name}",
              |  typ = ${p.typ},
              |  label = "${p.label}",
-             |  description = "${p.description}",
+             |  description = \"\"\"${p.description}\"\"\",
              |  default = \"\"\"${p.default}\"\"\"
              |)
            """.stripMargin

--- a/project/src/main/scala/ScapegoatInspectionsGenerator.scala
+++ b/project/src/main/scala/ScapegoatInspectionsGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019  All sonar-scala contributors
+ * Copyright (C) 2018-2020  All sonar-scala contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/src/test/scala/com/mwz/sonar/scala/qualityprofiles/RecommendedQualityProfileSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/qualityprofiles/RecommendedQualityProfileSpec.scala
@@ -52,8 +52,8 @@ class RecommendedQualityProfileSpec
     qualityProfile.isDefault shouldBe true
   }
 
-  it should "have 175 rules" in new Ctx {
-    rules.size shouldBe 176 // 61 from Scalastyle + 115 from Scapegoat
+  it should "have 179 rules" in new Ctx {
+    rules.size shouldBe 179 // 64 from Scalastyle + 115 from Scapegoat
   }
 
   it should "have all rules come from either the Scalastyle or the Scapegoat rules repositories" in new Ctx {

--- a/src/test/scala/com/mwz/sonar/scala/qualityprofiles/ScalastyleScapegoatQualityProfileSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/qualityprofiles/ScalastyleScapegoatQualityProfileSpec.scala
@@ -51,7 +51,7 @@ class ScalastyleScapegoatQualityProfileSpec
   }
 
   it should "define all Scalastyle + Scapegoat rules" in new Ctx {
-    qualityProfile.rules should have size 183 // 65 from Scalastyle + 118 from Scapegoat
+    qualityProfile.rules should have size 186 // 68 from Scalastyle + 118 from Scapegoat
   }
 
   it should "have all rules come from either the Scalastyle or the Scapegaot rules repositories" in new Ctx {

--- a/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleQualityProfileSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleQualityProfileSpec.scala
@@ -55,8 +55,8 @@ class ScalastyleQualityProfileSpec extends AnyFlatSpec with Matchers with LoneEl
       .map(_.clazz)
   }
 
-  it should "have 65 rules" in new Ctx {
-    rules should have size 65 // 39 default rules + 26 template instances
+  it should "have 68 rules" in new Ctx {
+    rules should have size 68 // 40 default rules + 28 template instances
   }
 
   it should "not activate templates" in new Ctx {

--- a/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepositorySpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/scalastyle/ScalastyleRulesRepositorySpec.scala
@@ -48,9 +48,9 @@ class ScalastyleRulesRepositorySpec extends AnyFlatSpec with Matchers with Inspe
   }
 
   it should "include all Scalastyle inspections" in new Ctx {
-    ScalastyleInspections.AllInspections should have size 69 // 29 templates + 40 default rules
+    ScalastyleInspections.AllInspections should have size 72 // 31 templates + 41 default rules
     ScalastyleInspections.AllInspectionsByClass.size shouldBe ScalastyleInspections.AllInspections.size
-    repository.rules should have size 95 // 29 templates + 40 default rules + 26 template instances
+    repository.rules should have size 100 // 31 templates + 41 default rules + 28 template instances
   }
 
   it should "have all rules with non-empty properties" in new Ctx {


### PR DESCRIPTION
I finally found some time to fork and publish a new version of Scalastyle.
See the [release notes](https://github.com/beautiful-scala/scalastyle/releases/tag/v1.1.0) and the following [thread](https://github.com/scalastyle/scalastyle/issues/327#issuecomment-570951273) for more details.

This PR updates Scalastyle to the new version. Here are the changes as far as the rules repository and the quality profiles in SonarQube are concerned: 

New Scalastyle rules:
- New `ForLoopChecker` rule - omit braces if you have a `yield` clause, otherwise, surround the contents with curly-braces, even if the contents are only a single line.
- New `WhileBraceChecker` - rule - it's recommended to never omit braces when using `while`.
- New `CaseBraceChecker` rule - braces aren't required in `case` clauses.

Scalastyle rule changes:
- `HeaderMatchesChecker` has new parameter `regex` to indicate whether to treat the header string as a regular expression; defaults to `false`
- `MethodLengthChecker` has new parameter `ignoreEmpty` to exclude empty lines from being counted; defaults to `false`
- `ForBraceChecker` has a new parameter `singleLineAllowed` to indicate whether a one-line `for` expressions with parentheses are allowed.
- `NonASCIICharacterChecker` has a new parameter `allowStringLiterals` to indicate whether non-ASCII scripts in string literals should be allowed.

It's getting difficult to keep track of the count of how many templates, non-template rules and template instances there are, so this diff of the generated inspections file between 1.0 and 1.1 was really useful in figuring that out.  

```diff
--- /Users/michaelwizner/dev/sonar-scala/inspections-1.0.scala	2020-01-06 01:44:52.000000000 +0000
+++ /Users/michaelwizner/dev/sonar-scala/inspections-1.1.scala	2020-01-06 02:03:21.000000000 +0000
@@ -60,6 +60,13 @@
           label = "Header",
           description = "The lines to compare against",
           default = ""
+        ),
+        Param(
+          name = "regex",
+          typ = BooleanType,
+          label = "Header Regex",
+          description = "Whether to treat the header string as a regular expression",
+          default = "false"
         )
       )
     ),
@@ -560,6 +567,13 @@
           label = "Ignore comments",
           description = "If set to true, comment lines in method body won't be counted",
           default = "false"
+        ),
+        Param(
+          name = "ignoreEmpty",
+          typ = BooleanType,
+          label = "Ignore empty lines",
+          description = "If set to true, empty lines in method body won't be counted",
+          default = "false"
         )
       )
     ),
@@ -923,7 +937,9 @@
       id = "for.brace",
       label = "Use braces in for comprehensions",
       description = "Checks that braces are used in for comprehensions",
-      extraDescription = None,
+      extraDescription = Some("""The singleLineAllowed property allows for constructions of the type:
+
+    for (i <- List(1,2,3)) yield i"""),
       justification = Some(
         """Usage of braces (rather than parentheses) within a for comprehension mean that you don't have to specify a semi-colon at the end of every line:
 
@@ -942,6 +958,40 @@
   To fix it, replace the () with {}. And then remove the ; at the end of the lines."""
       ),
       defaultLevel = WarningLevel,
+      params = List(
+        Param(
+          name = "singleLineAllowed",
+          typ = BooleanType,
+          label = "Allow parentheses for single-line for",
+          description = "For with parentheses allowed if everything is on one line",
+          default = "false"
+        )
+      )
+    ),
+    ScalastyleInspection(
+      clazz = "org.scalastyle.scalariform.ForLoopChecker",
+      id = "for.loop",
+      label = "Use parentheses in for loops",
+      description = "Checks that parentheses are used in for loops",
+      extraDescription = None,
+      justification = Some(
+        """For-comprehensions which lack a yield clause is actually a loop rather than a functional comprehension and it is usually
+   more readable to string the generators together between parentheses rather than using the syntactically-confusing } { construct:
+
+   for (x <- board.rows; y <- board.files) {
+     printf("(%d, %d)", x, y)
+   }
+
+   is preferred to
+
+   for {
+     x <- board.rows
+     y <- board.files
+   } {
+     printf("(%d, %d)", x, y)
+   }"""
+      ),
+      defaultLevel = WarningLevel,
       params = List()
     ),
     ScalastyleInspection(
@@ -1056,30 +1106,39 @@
     ScalastyleInspection(
       clazz = "org.scalastyle.scalariform.NonASCIICharacterChecker",
       id = "non.ascii.character.disallowed",
-      label = "Non ascii characters are not allowed",
-      description = "Some editors are unfriendly to non ascii characters.",
+      label = "Non ASCII characters are not allowed",
+      description = "Some editors are unfriendly to non ASCII characters.",
       extraDescription = None,
       justification = Some(
         """Scala allows unicode characters as operators and some editors misbehave when they see non-ascii character.
-            In a project collaborated by a community of developers. This check can be helpful in such situations.
+    In a project collaborated by a community of developers. This check can be helpful in such situations.
 
 
-            "value".match {
-            case "value" => println("matched")
-            ...
-            }
+    "value".match {
+    case "value" => println("matched")
+    ...
+    }
 
-            is preferred to
+    is preferred to
 
-            "value".match {
-            case "value" ‚áí println("matched")
-            ...
-            }
+    "value".match {
+    case "value" ‚áí println("matched")
+    ...
+    }
 
-            To fix it, replace the (unicode operator)‚áí with =>."""
+    To fix it, replace the (unicode operator)‚áí with =>."""
       ),
       defaultLevel = WarningLevel,
-      params = List()
+      params = List(
+        Param(
+          name = "allowStringLiterals",
+          typ = BooleanType,
+          label = "Allow non-ASCII scripts in string literals.",
+          description =
+            "White lists Unicode characters recognized by `\\p'{'Alnum'}'\\p'{'Punct'}'\\p'{'Sc'}'\\p'{'Space'}'` but not symbols like Emoji.",
+          default = "false"
+        )
+      )
     ),
     ScalastyleInspection(
       clazz = "org.scalastyle.file.IndentationChecker",
@@ -1230,6 +1289,30 @@
           default = "^set.+$"
         )
       )
+    ),
+    ScalastyleInspection(
+      clazz = "org.scalastyle.scalariform.WhileBraceChecker",
+      id = "while.brace",
+      label = "While body should have braces",
+      description = "Checks that while body have braces",
+      extraDescription = None,
+      justification = Some(
+        "While cannot be used in a pure-functional manner, that's why it's recommended to never omit braces according to Scala Style Guide."
+      ),
+      defaultLevel = WarningLevel,
+      params = List()
+    ),
+    ScalastyleInspection(
+      clazz = "org.scalastyle.scalariform.CaseBraceChecker",
+      id = "disallow.case.brace",
+      label = "Omit braces in case clauses",
+      description = "Checks that braces aren't used in case clauses",
+      extraDescription = None,
+      justification = Some(
+        "Braces aren't required in case clauses. They should be omitted according to Scala Style Guide."
+      ),
+      defaultLevel = WarningLevel,
+      params = List()
     )
   )
   val AllInspectionsByClass: Map[String, ScalastyleInspection] = AllInspections.map(i => i.clazz -> i).toMap
```

Closes #16.