### PR TITLE
Fix Scalastyle rule descriptions in SonarQube.

### DIFF
--- a/src/main/scala/com/mwz/sonar/scala/metadata/scalastyle/ScalastyleRules.scala
+++ b/src/main/scala/com/mwz/sonar/scala/metadata/scalastyle/ScalastyleRules.scala
@@ -71,7 +71,8 @@ object ScalastyleRules {
           val trimmed = line.trim
           val trippleQuote = trimmed.contains("```")
           // Replace all code blocks (inline and multiline) with ``.
-          val trimmedWithInlineCode = trimmed.replaceAll("^```(scala)?$", "`").replace("`", "``")
+          val withInlineCode = line.replaceAll("^```(scala)?$", "`").replace("`", "``")
+          val trimmedWithInlineCode = withInlineCode.trim
 
           acc match {
             // Empty line.
@@ -86,8 +87,8 @@ object ScalastyleRules {
                 Acc(
                   codeBlock = prev.contains("``") && !isEmpty,
                   isEmpty = false,
-                  s"$text$space$line",
-                  trimmedWithInlineCode
+                  s"$text$space$withInlineCode",
+                  withInlineCode
                 )
               } else
                 Acc(

--- a/src/test/scala/com/mwz/sonar/scala/metadata/scalastyle/ScalastyleRulesSpec.scala
+++ b/src/test/scala/com/mwz/sonar/scala/metadata/scalastyle/ScalastyleRulesSpec.scala
@@ -166,7 +166,7 @@ class ScalastyleRulesSpec extends AnyFlatSpec with Matchers with Inspectors with
         |  code block 2
         |```
         |
-        |line 4.
+        |line 4. `inline` and `inline 2`.
         |
         |```scala
         |code block 3
@@ -185,7 +185,7 @@ class ScalastyleRulesSpec extends AnyFlatSpec with Matchers with Inspectors with
         |``
         |code block 2
         |  code block 2
-        |`` line 4.
+        |`` line 4. ``inline`` and ``inline 2``.
         |``
         |code block 3
         |  code block 3


### PR DESCRIPTION
I missed a case where inline comments following a code block would not be wrapped correctly in double backticks (which is how code blocks are represented in SonarQube markdown syntax).